### PR TITLE
[codex] Batch /all mentions into 5-user messages

### DIFF
--- a/src/common/aws/dynamo/chat-statistics.ts
+++ b/src/common/aws/dynamo/chat-statistics.ts
@@ -66,7 +66,7 @@ export const getChatUsers = async (
   }
 }
 
-export const getChatUsersOrThrow = (chat_id: number | string) =>
+export const getStoredChatUsers = (chat_id: number | string) =>
   readChatUsers(chat_id)
 
 export const getUsersList = async (
@@ -74,7 +74,7 @@ export const getUsersList = async (
   query: string,
 ): Promise<string> => {
   try {
-    const users = await getChatUsersOrThrow(chat_id)
+    const users = await getStoredChatUsers(chat_id)
     const mentions = users
       .map((user: UserStat) => `@${user.username}`)
       .join(' ')

--- a/src/common/aws/dynamo/chat-statistics.ts
+++ b/src/common/aws/dynamo/chat-statistics.ts
@@ -58,7 +58,10 @@ export const getChatUsers = async (
   try {
     return await readChatUsers(chat_id)
   } catch (error) {
-    logger.error({ error }, 'Error while fetching chat users')
+    logger.error(
+      { chatId: String(chat_id), error },
+      'Error while fetching chat users',
+    )
     return []
   }
 }

--- a/src/common/aws/dynamo/chat-statistics.ts
+++ b/src/common/aws/dynamo/chat-statistics.ts
@@ -9,6 +9,11 @@ interface ChatStat {
   id: string
 }
 
+const readChatUsers = async (chat_id: number | string): Promise<UserStat[]> => {
+  const result = await getChatStatistic(chat_id)
+  return result?.users ?? []
+}
+
 const getChatStatistic = async (
   chat_id: number | string,
 ): Promise<ChatStat> => {
@@ -26,26 +31,26 @@ export const getChatUsers = async (
   chat_id: number | string,
 ): Promise<UserStat[]> => {
   try {
-    const result = await getChatStatistic(chat_id)
-    return result?.users ?? []
+    return await readChatUsers(chat_id)
   } catch (error) {
     logger.error({ error }, 'Error while fetching chat users')
     return []
   }
 }
 
+export const getChatUsersOrThrow = (chat_id: number | string) =>
+  readChatUsers(chat_id)
+
 export const getUsersList = async (
   chat_id: number | string,
   query: string,
 ): Promise<string> => {
   try {
-    const users = await getChatUsers(chat_id)
-    return (
-      users
-        .map((user: UserStat) => `@${user.username}`)
-        .join(' ')
-        .concat('\n') + query
-    )
+    const users = await getChatUsersOrThrow(chat_id)
+    const mentions = users
+      .map((user: UserStat) => `@${user.username}`)
+      .join(' ')
+    return mentions ? `${mentions}\n${query}` : query
   } catch (_e) {
     return 'Error while fetching users'
   }

--- a/src/common/aws/dynamo/chat-statistics.ts
+++ b/src/common/aws/dynamo/chat-statistics.ts
@@ -22,14 +22,26 @@ const getChatStatistic = async (
   return result.Items?.[0] as ChatStat
 }
 
+export const getChatUsers = async (
+  chat_id: number | string,
+): Promise<UserStat[]> => {
+  try {
+    const result = await getChatStatistic(chat_id)
+    return result?.users ?? []
+  } catch (error) {
+    logger.error({ error }, 'Error while fetching chat users')
+    return []
+  }
+}
+
 export const getUsersList = async (
   chat_id: number | string,
   query: string,
 ): Promise<string> => {
   try {
-    const result = await getChatStatistic(chat_id)
+    const users = await getChatUsers(chat_id)
     return (
-      result.users
+      users
         .map((user: UserStat) => `@${user.username}`)
         .join(' ')
         .concat('\n') + query

--- a/src/common/aws/dynamo/chat-statistics.ts
+++ b/src/common/aws/dynamo/chat-statistics.ts
@@ -5,18 +5,43 @@ import type { UserStat } from '../../types'
 import { dedent, dynamoPutItem, dynamoQuery, getUserName } from '../../utils'
 
 interface ChatStat {
+  chatId: string
+  chatInfo?: Chat
   users: UserStat[]
-  id: string
 }
 
-const readChatUsers = async (chat_id: number | string): Promise<UserStat[]> => {
-  const result = await getChatStatistic(chat_id)
-  return result?.users ?? []
+const isUserStat = (value: unknown): value is UserStat =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as Partial<UserStat>).id === 'number' &&
+  typeof (value as Partial<UserStat>).msgCount === 'number' &&
+  typeof (value as Partial<UserStat>).username === 'string'
+
+const toChatStat = (value: unknown): ChatStat | undefined => {
+  const chatStat = value as Partial<ChatStat> | null
+  if (
+    typeof chatStat !== 'object' ||
+    chatStat === null ||
+    typeof chatStat.chatId !== 'string'
+  ) {
+    return undefined
+  }
+
+  return {
+    chatId: chatStat.chatId,
+    chatInfo: chatStat.chatInfo,
+    users: Array.isArray(chatStat.users)
+      ? chatStat.users.filter(isUserStat)
+      : [],
+  }
 }
+
+const readChatUsers = async (chat_id: number | string): Promise<UserStat[]> =>
+  (await getChatStatistic(chat_id))?.users ?? []
 
 const getChatStatistic = async (
   chat_id: number | string,
-): Promise<ChatStat> => {
+): Promise<ChatStat | undefined> => {
   const params = {
     TableName: 'chat-statistics',
     ExpressionAttributeValues: { ':chatId': String(chat_id) },
@@ -24,7 +49,7 @@ const getChatStatistic = async (
   }
 
   const result = await dynamoQuery(params)
-  return result.Items?.[0] as ChatStat
+  return toChatStat(result.Items?.[0])
 }
 
 export const getChatUsers = async (
@@ -50,7 +75,7 @@ export const getUsersList = async (
     const mentions = users
       .map((user: UserStat) => `@${user.username}`)
       .join(' ')
-    return mentions ? `${mentions}\n${query}` : query
+    return [mentions, query].filter(Boolean).join('\n')
   } catch (_e) {
     return 'Error while fetching users'
   }

--- a/src/common/upstash/__tests__/chat-history.test.ts
+++ b/src/common/upstash/__tests__/chat-history.test.ts
@@ -4,8 +4,6 @@ import * as utils from '../../utils'
 import {
   DEFAULT_AGENT_HISTORY_LIMIT,
   formatHistoryForDisplay,
-  getHistory,
-  getRawHistory,
   getRecentRawHistory,
 } from '../chat-history'
 import * as client from '../client'
@@ -149,39 +147,5 @@ describe('getRecentRawHistory', () => {
       },
     )
     expect(history.map((message) => message.message_id)).toEqual([2, 3])
-  })
-
-  test('uses the exact same redis fetch as full history and only trims the tail locally', async () => {
-    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_740_000_000_000)
-    const messages = [
-      createMessage(1),
-      createMessage(2),
-      createMessage(3),
-      createMessage(4),
-    ]
-    mockZrange.mockResolvedValue(messages)
-
-    const rawHistory = await getRawHistory(777)
-    const recentHistory = await getRecentRawHistory(777, 2)
-    const formattedHistory = await getHistory(777)
-
-    expect(mockZrange).toHaveBeenCalledWith(
-      'chat-history:777',
-      expect.any(Number),
-      expect.any(Number),
-      {
-        byScore: true,
-      },
-    )
-
-    expect(rawHistory).toEqual(messages)
-    expect(recentHistory).toEqual(messages.slice(-2))
-    expect(
-      formattedHistory.map(
-        (entry) => JSON.parse(entry.content[0]?.text ?? '{}').message_id,
-      ),
-    ).toEqual(messages.map((message) => message.message_id))
-
-    nowSpy.mockRestore()
   })
 })

--- a/src/common/upstash/__tests__/chat-history.test.ts
+++ b/src/common/upstash/__tests__/chat-history.test.ts
@@ -161,9 +161,14 @@ describe('getRecentRawHistory', () => {
     const recentHistory = await getRecentRawHistory(777, 2)
     const formattedHistory = await getHistory(777)
 
-    expect(mockZrange).toHaveBeenCalledTimes(3)
-    expect(mockZrange.mock.calls[0]).toEqual(mockZrange.mock.calls[1])
-    expect(mockZrange.mock.calls[1]).toEqual(mockZrange.mock.calls[2])
+    expect(mockZrange).toHaveBeenCalledWith(
+      'chat-history:777',
+      expect.any(Number),
+      expect.any(Number),
+      {
+        byScore: true,
+      },
+    )
 
     expect(rawHistory).toEqual(messages)
     expect(recentHistory).toEqual(messages.slice(-2))

--- a/src/common/upstash/__tests__/chat-history.test.ts
+++ b/src/common/upstash/__tests__/chat-history.test.ts
@@ -4,8 +4,6 @@ import * as utils from '../../utils'
 import {
   DEFAULT_AGENT_HISTORY_LIMIT,
   formatHistoryForDisplay,
-  getHistory,
-  getRawHistory,
   getRecentRawHistory,
 } from '../chat-history'
 import * as client from '../client'
@@ -131,15 +129,6 @@ describe('formatHistoryForDisplay', () => {
 })
 
 describe('getRecentRawHistory', () => {
-  test('returns full raw history when no explicit limit is provided', async () => {
-    const messages = [createMessage(1), createMessage(2), createMessage(3)]
-    mockZrange.mockResolvedValue(messages)
-
-    const history = await getRawHistory(777)
-
-    expect(history).toEqual(messages)
-  })
-
   test('reads recent history through the same raw-history path and slices locally', async () => {
     mockZrange.mockResolvedValue([
       createMessage(1),
@@ -158,32 +147,5 @@ describe('getRecentRawHistory', () => {
       },
     )
     expect(history.map((message) => message.message_id)).toEqual([2, 3])
-  })
-
-  test('formats raw history entries for model interactions', async () => {
-    const messages = [
-      createMessage(1),
-      createMessage(2, {
-        from: {
-          id: 1002,
-          is_bot: true,
-          first_name: 'Bot',
-        },
-      }),
-    ]
-    mockZrange.mockResolvedValue(messages)
-
-    const history = await getHistory(777)
-
-    expect(history).toEqual([
-      {
-        role: 'user',
-        content: [{ type: 'text', text: JSON.stringify(messages[0]) }],
-      },
-      {
-        role: 'model',
-        content: [{ type: 'text', text: JSON.stringify(messages[1]) }],
-      },
-    ])
   })
 })

--- a/src/common/upstash/__tests__/chat-history.test.ts
+++ b/src/common/upstash/__tests__/chat-history.test.ts
@@ -1,18 +1,6 @@
 import type { Message } from 'telegram-typings'
 
-const mockIsAiEnabledChat = jest.fn()
-const mockZrange = jest.fn()
-
-jest.mock('../../utils', () => ({
-  isAiEnabledChat: mockIsAiEnabledChat,
-}))
-
-jest.mock('../client', () => ({
-  getRedisClient: jest.fn(() => ({
-    zrange: mockZrange,
-  })),
-}))
-
+import * as utils from '../../utils'
 import {
   DEFAULT_AGENT_HISTORY_LIMIT,
   formatHistoryForDisplay,
@@ -20,6 +8,17 @@ import {
   getRawHistory,
   getRecentRawHistory,
 } from '../chat-history'
+import * as client from '../client'
+
+const mockZrange = jest.fn()
+
+const mockGetRedisClient = jest
+  .spyOn(client, 'getRedisClient')
+  .mockReturnValue({
+    zrange: mockZrange,
+  } as unknown as ReturnType<typeof client.getRedisClient>)
+
+const mockIsAiEnabledChat = jest.spyOn(utils, 'isAiEnabledChat')
 
 function createMessage(
   messageId: number,
@@ -43,6 +42,11 @@ beforeEach(() => {
   mockZrange.mockReset()
   mockIsAiEnabledChat.mockReset()
   mockIsAiEnabledChat.mockReturnValue(true)
+})
+
+afterAll(() => {
+  mockGetRedisClient.mockRestore()
+  mockIsAiEnabledChat.mockRestore()
 })
 
 describe('formatHistoryForDisplay', () => {

--- a/src/common/upstash/__tests__/chat-history.test.ts
+++ b/src/common/upstash/__tests__/chat-history.test.ts
@@ -1,6 +1,18 @@
 import type { Message } from 'telegram-typings'
 
-import * as utils from '../../utils'
+const mockIsAiEnabledChat = jest.fn()
+const mockZrange = jest.fn()
+
+jest.mock('../../utils', () => ({
+  isAiEnabledChat: mockIsAiEnabledChat,
+}))
+
+jest.mock('../client', () => ({
+  getRedisClient: jest.fn(() => ({
+    zrange: mockZrange,
+  })),
+}))
+
 import {
   DEFAULT_AGENT_HISTORY_LIMIT,
   formatHistoryForDisplay,
@@ -8,15 +20,6 @@ import {
   getRawHistory,
   getRecentRawHistory,
 } from '../chat-history'
-import * as client from '../client'
-
-const mockZrange = jest.fn()
-
-jest.spyOn(client, 'getRedisClient').mockReturnValue({
-  zrange: mockZrange,
-} as unknown as ReturnType<typeof client.getRedisClient>)
-
-jest.spyOn(utils, 'isAiEnabledChat').mockReturnValue(true)
 
 function createMessage(
   messageId: number,
@@ -38,6 +41,8 @@ function createMessage(
 
 beforeEach(() => {
   mockZrange.mockReset()
+  mockIsAiEnabledChat.mockReset()
+  mockIsAiEnabledChat.mockReturnValue(true)
 })
 
 describe('formatHistoryForDisplay', () => {

--- a/src/common/upstash/__tests__/chat-history.test.ts
+++ b/src/common/upstash/__tests__/chat-history.test.ts
@@ -4,7 +4,6 @@ import * as utils from '../../utils'
 import {
   DEFAULT_AGENT_HISTORY_LIMIT,
   formatHistoryForDisplay,
-  getRawHistory,
   getRecentRawHistory,
 } from '../chat-history'
 import * as client from '../client'
@@ -130,25 +129,6 @@ describe('formatHistoryForDisplay', () => {
 })
 
 describe('getRecentRawHistory', () => {
-  test('getRawHistory uses the shared Redis range query shape', async () => {
-    mockZrange.mockResolvedValue([
-      createMessage(1),
-      createMessage(2),
-      createMessage(3),
-    ])
-
-    await getRawHistory(777)
-
-    expect(mockZrange).toHaveBeenCalledWith(
-      'chat-history:777',
-      expect.any(Number),
-      expect.any(Number),
-      {
-        byScore: true,
-      },
-    )
-  })
-
   test('reads recent history through the same raw-history path and slices locally', async () => {
     mockZrange.mockResolvedValue([
       createMessage(1),

--- a/src/common/upstash/__tests__/chat-history.test.ts
+++ b/src/common/upstash/__tests__/chat-history.test.ts
@@ -4,6 +4,8 @@ import * as utils from '../../utils'
 import {
   DEFAULT_AGENT_HISTORY_LIMIT,
   formatHistoryForDisplay,
+  getHistory,
+  getRawHistory,
   getRecentRawHistory,
 } from '../chat-history'
 import * as client from '../client'
@@ -129,6 +131,15 @@ describe('formatHistoryForDisplay', () => {
 })
 
 describe('getRecentRawHistory', () => {
+  test('returns full raw history when no explicit limit is provided', async () => {
+    const messages = [createMessage(1), createMessage(2), createMessage(3)]
+    mockZrange.mockResolvedValue(messages)
+
+    const history = await getRawHistory(777)
+
+    expect(history).toEqual(messages)
+  })
+
   test('reads recent history through the same raw-history path and slices locally', async () => {
     mockZrange.mockResolvedValue([
       createMessage(1),
@@ -147,5 +158,32 @@ describe('getRecentRawHistory', () => {
       },
     )
     expect(history.map((message) => message.message_id)).toEqual([2, 3])
+  })
+
+  test('formats raw history entries for model interactions', async () => {
+    const messages = [
+      createMessage(1),
+      createMessage(2, {
+        from: {
+          id: 1002,
+          is_bot: true,
+          first_name: 'Bot',
+        },
+      }),
+    ]
+    mockZrange.mockResolvedValue(messages)
+
+    const history = await getHistory(777)
+
+    expect(history).toEqual([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: JSON.stringify(messages[0]) }],
+      },
+      {
+        role: 'model',
+        content: [{ type: 'text', text: JSON.stringify(messages[1]) }],
+      },
+    ])
   })
 })

--- a/src/common/upstash/__tests__/chat-history.test.ts
+++ b/src/common/upstash/__tests__/chat-history.test.ts
@@ -130,7 +130,7 @@ describe('formatHistoryForDisplay', () => {
 })
 
 describe('getRecentRawHistory', () => {
-  test('getRawHistory and getRecentRawHistory share the same Redis range query', async () => {
+  test('getRawHistory uses the shared Redis range query shape', async () => {
     mockZrange.mockResolvedValue([
       createMessage(1),
       createMessage(2),
@@ -138,19 +138,8 @@ describe('getRecentRawHistory', () => {
     ])
 
     await getRawHistory(777)
-    await getRecentRawHistory(777, 2)
 
-    expect(mockZrange).toHaveBeenNthCalledWith(
-      1,
-      'chat-history:777',
-      expect.any(Number),
-      expect.any(Number),
-      {
-        byScore: true,
-      },
-    )
-    expect(mockZrange).toHaveBeenNthCalledWith(
-      2,
+    expect(mockZrange).toHaveBeenCalledWith(
       'chat-history:777',
       expect.any(Number),
       expect.any(Number),

--- a/src/common/upstash/__tests__/chat-history.test.ts
+++ b/src/common/upstash/__tests__/chat-history.test.ts
@@ -4,6 +4,7 @@ import * as utils from '../../utils'
 import {
   DEFAULT_AGENT_HISTORY_LIMIT,
   formatHistoryForDisplay,
+  getRawHistory,
   getRecentRawHistory,
 } from '../chat-history'
 import * as client from '../client'
@@ -129,6 +130,36 @@ describe('formatHistoryForDisplay', () => {
 })
 
 describe('getRecentRawHistory', () => {
+  test('getRawHistory and getRecentRawHistory share the same Redis range query', async () => {
+    mockZrange.mockResolvedValue([
+      createMessage(1),
+      createMessage(2),
+      createMessage(3),
+    ])
+
+    await getRawHistory(777)
+    await getRecentRawHistory(777, 2)
+
+    expect(mockZrange).toHaveBeenNthCalledWith(
+      1,
+      'chat-history:777',
+      expect.any(Number),
+      expect.any(Number),
+      {
+        byScore: true,
+      },
+    )
+    expect(mockZrange).toHaveBeenNthCalledWith(
+      2,
+      'chat-history:777',
+      expect.any(Number),
+      expect.any(Number),
+      {
+        byScore: true,
+      },
+    )
+  })
+
   test('reads recent history through the same raw-history path and slices locally', async () => {
     mockZrange.mockResolvedValue([
       createMessage(1),

--- a/src/telegram-bot/users/__tests__/index.test.ts
+++ b/src/telegram-bot/users/__tests__/index.test.ts
@@ -1,0 +1,50 @@
+import {
+  buildAllMentionBatches,
+  filterMentionableUsers,
+  isTelegramUsername,
+} from '../index'
+
+describe('users /all helpers', () => {
+  test('isTelegramUsername enforces Telegram username length rules', () => {
+    expect(isTelegramUsername('alpha1')).toBe(true)
+    expect(isTelegramUsername('@bravo_2')).toBe(true)
+    expect(isTelegramUsername('shrt')).toBe(false)
+    expect(isTelegramUsername('a'.repeat(33))).toBe(false)
+    expect(isTelegramUsername('bad name')).toBe(false)
+  })
+
+  test('filterMentionableUsers keeps only users with valid Telegram usernames', () => {
+    expect(
+      filterMentionableUsers([
+        { id: 1, username: 'alpha1' },
+        { id: 2, username: '@bravo_2' },
+        { id: 3, username: 'shrt' },
+        { id: 4, username: 'bad name' },
+        { id: 0, username: 'charlie_3' },
+      ]),
+    ).toEqual([
+      { id: 1, username: 'alpha1' },
+      { id: 2, username: '@bravo_2' },
+    ])
+  })
+
+  test('buildAllMentionBatches batches by five and keeps query only in the first batch', () => {
+    expect(
+      buildAllMentionBatches(
+        [
+          { id: 1, username: 'alpha1' },
+          { id: 2, username: '@bravo_2' },
+          { id: 3, username: 'charlie_3' },
+          { id: 4, username: 'delta_4' },
+          { id: 5, username: 'echo_5' },
+          { id: 6, username: 'foxtrot_6' },
+          { id: 7, username: 'shrt' },
+        ],
+        'wake up',
+      ),
+    ).toEqual([
+      '@alpha1 @bravo_2 @charlie_3 @delta_4 @echo_5\nwake up',
+      '@foxtrot_6',
+    ])
+  })
+})

--- a/src/telegram-bot/users/__tests__/index.test.ts
+++ b/src/telegram-bot/users/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import {
   buildAllMentionBatches,
+  buildBatchSendOptions,
   filterMentionableUsers,
   isTelegramUsername,
 } from '../index'
@@ -46,5 +47,35 @@ describe('users /all helpers', () => {
       '@alpha1 @bravo_2 @charlie_3 @delta_4 @echo_5\nwake up',
       '@foxtrot_6',
     ])
+  })
+
+  test('buildAllMentionBatches falls back to the default batch size when chunk size is invalid', () => {
+    expect(
+      buildAllMentionBatches(
+        [
+          { id: 1, username: 'alpha1' },
+          { id: 2, username: 'bravo_2' },
+          { id: 3, username: 'charlie_3' },
+          { id: 4, username: 'delta_4' },
+          { id: 5, username: 'echo_5' },
+          { id: 6, username: 'foxtrot_6' },
+        ],
+        'wake up',
+        0,
+      ),
+    ).toEqual([
+      '@alpha1 @bravo_2 @charlie_3 @delta_4 @echo_5\nwake up',
+      '@foxtrot_6',
+    ])
+  })
+
+  test('buildBatchSendOptions preserves reply and topic context for follow-up batches', () => {
+    expect(buildBatchSendOptions(91, 777)).toEqual({
+      reply_parameters: { message_id: 91 },
+      message_thread_id: 777,
+    })
+    expect(buildBatchSendOptions(undefined, 777)).toEqual({
+      message_thread_id: 777,
+    })
   })
 })

--- a/src/telegram-bot/users/__tests__/index.test.ts
+++ b/src/telegram-bot/users/__tests__/index.test.ts
@@ -36,7 +36,6 @@ describe('users /all helpers', () => {
           { username: 'delta_4' },
           { username: 'echo_5' },
           { username: 'foxtrot_6' },
-          { username: 'shrt' },
         ],
         'wake up',
       ),

--- a/src/telegram-bot/users/__tests__/index.test.ts
+++ b/src/telegram-bot/users/__tests__/index.test.ts
@@ -17,29 +17,26 @@ describe('users /all helpers', () => {
   test('filterMentionableUsers keeps only users with valid Telegram usernames', () => {
     expect(
       filterMentionableUsers([
-        { id: 1, username: 'alpha1' },
-        { id: 2, username: '@bravo_2' },
-        { id: 3, username: 'shrt' },
-        { id: 4, username: 'bad name' },
-        { id: 0, username: 'charlie_3' },
+        { username: 'alpha1' },
+        { username: '@bravo_2' },
+        { username: 'shrt' },
+        { username: 'bad name' },
+        {},
       ]),
-    ).toEqual([
-      { id: 1, username: 'alpha1' },
-      { id: 2, username: '@bravo_2' },
-    ])
+    ).toEqual([{ username: 'alpha1' }, { username: '@bravo_2' }])
   })
 
   test('buildAllMentionBatches batches by five and keeps query only in the first batch', () => {
     expect(
       buildAllMentionBatches(
         [
-          { id: 1, username: 'alpha1' },
-          { id: 2, username: '@bravo_2' },
-          { id: 3, username: 'charlie_3' },
-          { id: 4, username: 'delta_4' },
-          { id: 5, username: 'echo_5' },
-          { id: 6, username: 'foxtrot_6' },
-          { id: 7, username: 'shrt' },
+          { username: 'alpha1' },
+          { username: '@bravo_2' },
+          { username: 'charlie_3' },
+          { username: 'delta_4' },
+          { username: 'echo_5' },
+          { username: 'foxtrot_6' },
+          { username: 'shrt' },
         ],
         'wake up',
       ),
@@ -53,12 +50,12 @@ describe('users /all helpers', () => {
     expect(
       buildAllMentionBatches(
         [
-          { id: 1, username: 'alpha1' },
-          { id: 2, username: 'bravo_2' },
-          { id: 3, username: 'charlie_3' },
-          { id: 4, username: 'delta_4' },
-          { id: 5, username: 'echo_5' },
-          { id: 6, username: 'foxtrot_6' },
+          { username: 'alpha1' },
+          { username: 'bravo_2' },
+          { username: 'charlie_3' },
+          { username: 'delta_4' },
+          { username: 'echo_5' },
+          { username: 'foxtrot_6' },
         ],
         'wake up',
         0,

--- a/src/telegram-bot/users/index.ts
+++ b/src/telegram-bot/users/index.ts
@@ -8,6 +8,7 @@ import {
   getFormattedChatStatistics,
   getFormattedMetrics,
   isAiEnabledChat,
+  logger,
 } from '@tg-bot/common'
 import { getDailyStatistics } from './daily-statistics'
 
@@ -17,16 +18,11 @@ const TELEGRAM_USERNAME_MAX_LENGTH = 32
 const ALL_MENTION_BATCH_SIZE = 5
 
 interface MentionableUser {
-  id?: number
   username?: string
 }
 
-export function normalizeTelegramUsername(username: string): string {
+function normalizeTelegramUsername(username: string): string {
   return username.trim().replace(/^@/, '')
-}
-
-export function getMentionLabel(user: { username: string }): string {
-  return `@${normalizeTelegramUsername(user.username)}`
 }
 
 export function isTelegramUsername(username: string): boolean {
@@ -39,10 +35,12 @@ export function isTelegramUsername(username: string): boolean {
 }
 
 function buildMentionMessage(users: Array<{ username: string }>) {
-  return users.map((user) => getMentionLabel(user)).join(' ')
+  return users
+    .map(({ username }) => `@${normalizeTelegramUsername(username)}`)
+    .join(' ')
 }
 
-export function buildAllMessage(
+function buildAllMessage(
   users: Array<{ username: string }>,
   query = '',
 ): string {
@@ -52,10 +50,8 @@ export function buildAllMessage(
 }
 
 export function filterMentionableUsers(users: MentionableUser[]) {
-  return users.filter((user): user is { id: number; username: string } =>
-    Boolean(
-      user.id && user.username?.trim() && isTelegramUsername(user.username),
-    ),
+  return users.filter((user): user is { username: string } =>
+    Boolean(user.username?.trim() && isTelegramUsername(user.username)),
   )
 }
 
@@ -136,45 +132,47 @@ const setupUsersCommands = (bot: Bot) => {
     const { text, replyId } = getCommandData(ctx.message)
     const chatId = ctx.chat?.id
     const messageThreadId = ctx.message?.message_thread_id
+    const replyOptions = buildBatchSendOptions(replyId, messageThreadId)
     if (!chatId) {
       return
     }
 
-    let fetchedUsers: Awaited<ReturnType<typeof getChatUsersOrThrow>>
+    let mentionBatches: string[]
     try {
-      fetchedUsers = await getChatUsersOrThrow(chatId)
-    } catch {
-      return ctx.reply('Error while fetching users', {
-        reply_parameters: { message_id: replyId },
-      })
-    }
-
-    const [firstMessage, ...restMessages] = buildAllMentionBatches(
-      fetchedUsers,
-      text,
-    )
-
-    if (!firstMessage) {
-      return ctx.reply('No valid usernames found', {
-        reply_parameters: { message_id: replyId },
-      })
-    }
-
-    let lastMessage = await ctx.api.sendMessage(
-      chatId,
-      firstMessage,
-      buildBatchSendOptions(replyId, messageThreadId),
-    )
-
-    for (const message of restMessages) {
-      lastMessage = await ctx.api.sendMessage(
-        chatId,
-        message,
-        buildBatchSendOptions(lastMessage.message_id, messageThreadId),
+      mentionBatches = buildAllMentionBatches(
+        await getChatUsersOrThrow(chatId),
+        text,
       )
+    } catch (error) {
+      logger.error({ chatId, error }, 'Failed to fetch /all chat users')
+      return ctx.reply('Error while fetching users', replyOptions)
     }
 
-    return lastMessage
+    const [firstMessage, ...restMessages] = mentionBatches
+    if (!firstMessage) {
+      return ctx.reply('No valid usernames found', replyOptions)
+    }
+
+    try {
+      let lastMessage = await ctx.api.sendMessage(
+        chatId,
+        firstMessage,
+        replyOptions,
+      )
+
+      for (const message of restMessages) {
+        lastMessage = await ctx.api.sendMessage(
+          chatId,
+          message,
+          buildBatchSendOptions(lastMessage.message_id, messageThreadId),
+        )
+      }
+
+      return lastMessage
+    } catch (error) {
+      logger.error({ chatId, error }, 'Failed to send /all mention batches')
+      return ctx.reply('Failed to send all mention batches', replyOptions)
+    }
   })
 
   bot.command('x', async (ctx) => {

--- a/src/telegram-bot/users/index.ts
+++ b/src/telegram-bot/users/index.ts
@@ -3,10 +3,10 @@ import type { Bot } from 'grammy/web'
 
 import {
   getChatName,
-  getChatUsersOrThrow,
   getCommandData,
   getFormattedChatStatistics,
   getFormattedMetrics,
+  getStoredChatUsers,
   isAiEnabledChat,
   logger,
 } from '@tg-bot/common'
@@ -139,20 +139,20 @@ const setupUsersCommands = (bot: Bot) => {
     }
 
     let mentionableUsers: Array<{ username: string }>
+    let totalMentionableUsers = 0
     try {
       mentionableUsers = filterMentionableUsers(
-        await getChatUsersOrThrow(chatId),
+        await getStoredChatUsers(chatId),
       )
     } catch (error) {
       logger.error({ chatId, error }, 'Failed to fetch /all chat users')
       return ctx.reply('Error while fetching users', replyOptions)
     }
 
-    if (mentionableUsers.length > MAX_ALL_MENTION_USERS) {
-      return ctx.reply(
-        `Too many valid usernames found for /all. Limit is ${MAX_ALL_MENTION_USERS} users.`,
-        replyOptions,
-      )
+    totalMentionableUsers = mentionableUsers.length
+    const isTruncated = totalMentionableUsers > MAX_ALL_MENTION_USERS
+    if (isTruncated) {
+      mentionableUsers = mentionableUsers.slice(0, MAX_ALL_MENTION_USERS)
     }
 
     const mentionBatches = buildAllMentionBatches(mentionableUsers, text)
@@ -173,6 +173,13 @@ const setupUsersCommands = (bot: Bot) => {
           chatId,
           message,
           buildBatchSendOptions(lastMessage.message_id, messageThreadId),
+        )
+      }
+
+      if (isTruncated) {
+        await ctx.reply(
+          `Sent mentions for first ${MAX_ALL_MENTION_USERS} of ${totalMentionableUsers} valid usernames.`,
+          replyOptions,
         )
       }
 

--- a/src/telegram-bot/users/index.ts
+++ b/src/telegram-bot/users/index.ts
@@ -16,6 +16,8 @@ const USERNAME_REGEX = /^[A-Za-z0-9_]+$/
 const TELEGRAM_USERNAME_MIN_LENGTH = 5
 const TELEGRAM_USERNAME_MAX_LENGTH = 32
 const ALL_MENTION_BATCH_SIZE = 5
+const MAX_ALL_MENTION_BATCHES = 10
+const MAX_ALL_MENTION_USERS = ALL_MENTION_BATCH_SIZE * MAX_ALL_MENTION_BATCHES
 
 interface MentionableUser {
   username?: string
@@ -76,12 +78,11 @@ function chunkUsers<T>(users: T[], chunkSize: number): T[][] {
 }
 
 export function buildAllMentionBatches(
-  users: MentionableUser[],
+  users: Array<{ username: string }>,
   query = '',
   chunkSize = ALL_MENTION_BATCH_SIZE,
 ): string[] {
-  const validUsers = filterMentionableUsers(users)
-  return chunkUsers(validUsers, chunkSize).map((userChunk, index) =>
+  return chunkUsers(users, chunkSize).map((userChunk, index) =>
     buildAllMessage(userChunk, index === 0 ? query : ''),
   )
 }
@@ -137,17 +138,24 @@ const setupUsersCommands = (bot: Bot) => {
       return
     }
 
-    let mentionBatches: string[]
+    let mentionableUsers: Array<{ username: string }>
     try {
-      mentionBatches = buildAllMentionBatches(
+      mentionableUsers = filterMentionableUsers(
         await getChatUsersOrThrow(chatId),
-        text,
       )
     } catch (error) {
       logger.error({ chatId, error }, 'Failed to fetch /all chat users')
       return ctx.reply('Error while fetching users', replyOptions)
     }
 
+    if (mentionableUsers.length > MAX_ALL_MENTION_USERS) {
+      return ctx.reply(
+        `Too many valid usernames found for /all. Limit is ${MAX_ALL_MENTION_USERS} users.`,
+        replyOptions,
+      )
+    }
+
+    const mentionBatches = buildAllMentionBatches(mentionableUsers, text)
     const [firstMessage, ...restMessages] = mentionBatches
     if (!firstMessage) {
       return ctx.reply('No valid usernames found', replyOptions)

--- a/src/telegram-bot/users/index.ts
+++ b/src/telegram-bot/users/index.ts
@@ -3,13 +3,39 @@ import type { Bot } from 'grammy/web'
 
 import {
   getChatName,
+  getChatUsers,
   getCommandData,
   getFormattedChatStatistics,
   getFormattedMetrics,
-  getUsersList,
   isAiEnabledChat,
 } from '@tg-bot/common'
 import { getDailyStatistics } from './daily-statistics'
+
+const USERNAME_REGEX = /^[A-Za-z0-9_]{3,}$/
+const ALL_MENTION_BATCH_SIZE = 5
+
+function getMentionLabel(user: { username: string }): string {
+  const normalized = user.username.trim()
+  return normalized.startsWith('@') ? normalized : `@${normalized}`
+}
+
+function isTelegramUsername(username: string): boolean {
+  return USERNAME_REGEX.test(username.trim().replace(/^@/, ''))
+}
+
+function buildMentionMessage(users: Array<{ username: string }>) {
+  return users.map((user) => getMentionLabel(user)).join(' ')
+}
+
+function chunkUsers<T>(users: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = []
+
+  for (let index = 0; index < users.length; index += chunkSize) {
+    chunks.push(users.slice(index, index + chunkSize))
+  }
+
+  return chunks
+}
 
 const setupUsersCommands = (bot: Bot) => {
   bot.command('z', async (ctx) =>
@@ -41,9 +67,36 @@ const setupUsersCommands = (bot: Bot) => {
 
   bot.command('all', async (ctx) => {
     const { text, replyId } = getCommandData(ctx.message)
-    return ctx.reply(await getUsersList(ctx.chat?.id ?? '', text), {
+    const users = (await getChatUsers(ctx.chat?.id ?? '')).filter(
+      (user) =>
+        user.id && user.username?.trim() && isTelegramUsername(user.username),
+    )
+
+    if (users.length === 0) {
+      return ctx.reply('Error while fetching users', {
+        reply_parameters: { message_id: replyId },
+      })
+    }
+
+    const userChunks = chunkUsers(users, ALL_MENTION_BATCH_SIZE)
+    const query = text.trim()
+    const [firstChunk, ...restChunks] = userChunks
+
+    const firstMentions = buildMentionMessage(firstChunk)
+    const firstMessage = query ? `${firstMentions}\n${query}` : firstMentions
+
+    let lastMessage = await ctx.api.sendMessage(ctx.chat.id, firstMessage, {
       reply_parameters: { message_id: replyId },
     })
+
+    for (const userChunk of restChunks) {
+      const mentions = buildMentionMessage(userChunk)
+      const message = query ? `${mentions}\n${query}` : mentions
+
+      lastMessage = await ctx.api.sendMessage(ctx.chat.id, message)
+    }
+
+    return lastMessage
   })
 
   bot.command('x', async (ctx) => {

--- a/src/telegram-bot/users/index.ts
+++ b/src/telegram-bot/users/index.ts
@@ -59,11 +59,21 @@ export function filterMentionableUsers(users: MentionableUser[]) {
   )
 }
 
+function normalizeChunkSize(chunkSize: number): number {
+  if (!Number.isFinite(chunkSize)) {
+    return ALL_MENTION_BATCH_SIZE
+  }
+
+  const normalizedChunkSize = Math.trunc(chunkSize)
+  return normalizedChunkSize > 0 ? normalizedChunkSize : ALL_MENTION_BATCH_SIZE
+}
+
 function chunkUsers<T>(users: T[], chunkSize: number): T[][] {
   const chunks: T[][] = []
+  const safeChunkSize = normalizeChunkSize(chunkSize)
 
-  for (let index = 0; index < users.length; index += chunkSize) {
-    chunks.push(users.slice(index, index + chunkSize))
+  for (let index = 0; index < users.length; index += safeChunkSize) {
+    chunks.push(users.slice(index, index + safeChunkSize))
   }
 
   return chunks
@@ -78,6 +88,20 @@ export function buildAllMentionBatches(
   return chunkUsers(validUsers, chunkSize).map((userChunk, index) =>
     buildAllMessage(userChunk, index === 0 ? query : ''),
   )
+}
+
+export function buildBatchSendOptions(
+  replyToMessageId?: number,
+  messageThreadId?: number,
+) {
+  return {
+    ...(typeof replyToMessageId === 'number'
+      ? { reply_parameters: { message_id: replyToMessageId } }
+      : {}),
+    ...(typeof messageThreadId === 'number'
+      ? { message_thread_id: messageThreadId }
+      : {}),
+  }
 }
 
 const setupUsersCommands = (bot: Bot) => {
@@ -111,6 +135,7 @@ const setupUsersCommands = (bot: Bot) => {
   bot.command('all', async (ctx) => {
     const { text, replyId } = getCommandData(ctx.message)
     const chatId = ctx.chat?.id
+    const messageThreadId = ctx.message?.message_thread_id
     if (!chatId) {
       return
     }
@@ -124,22 +149,29 @@ const setupUsersCommands = (bot: Bot) => {
       })
     }
 
-    const users = filterMentionableUsers(fetchedUsers)
+    const [firstMessage, ...restMessages] = buildAllMentionBatches(
+      fetchedUsers,
+      text,
+    )
 
-    if (users.length === 0) {
+    if (!firstMessage) {
       return ctx.reply('No valid usernames found', {
         reply_parameters: { message_id: replyId },
       })
     }
 
-    const [firstMessage, ...restMessages] = buildAllMentionBatches(users, text)
-
-    let lastMessage = await ctx.api.sendMessage(chatId, firstMessage, {
-      reply_parameters: { message_id: replyId },
-    })
+    let lastMessage = await ctx.api.sendMessage(
+      chatId,
+      firstMessage,
+      buildBatchSendOptions(replyId, messageThreadId),
+    )
 
     for (const message of restMessages) {
-      lastMessage = await ctx.api.sendMessage(chatId, message)
+      lastMessage = await ctx.api.sendMessage(
+        chatId,
+        message,
+        buildBatchSendOptions(lastMessage.message_id, messageThreadId),
+      )
     }
 
     return lastMessage

--- a/src/telegram-bot/users/index.ts
+++ b/src/telegram-bot/users/index.ts
@@ -3,7 +3,7 @@ import type { Bot } from 'grammy/web'
 
 import {
   getChatName,
-  getChatUsers,
+  getChatUsersOrThrow,
   getCommandData,
   getFormattedChatStatistics,
   getFormattedMetrics,
@@ -11,20 +11,52 @@ import {
 } from '@tg-bot/common'
 import { getDailyStatistics } from './daily-statistics'
 
-const USERNAME_REGEX = /^[A-Za-z0-9_]{3,}$/
+const USERNAME_REGEX = /^[A-Za-z0-9_]+$/
+const TELEGRAM_USERNAME_MIN_LENGTH = 5
+const TELEGRAM_USERNAME_MAX_LENGTH = 32
 const ALL_MENTION_BATCH_SIZE = 5
 
-function getMentionLabel(user: { username: string }): string {
-  const normalized = user.username.trim()
-  return normalized.startsWith('@') ? normalized : `@${normalized}`
+interface MentionableUser {
+  id?: number
+  username?: string
 }
 
-function isTelegramUsername(username: string): boolean {
-  return USERNAME_REGEX.test(username.trim().replace(/^@/, ''))
+export function normalizeTelegramUsername(username: string): string {
+  return username.trim().replace(/^@/, '')
+}
+
+export function getMentionLabel(user: { username: string }): string {
+  return `@${normalizeTelegramUsername(user.username)}`
+}
+
+export function isTelegramUsername(username: string): boolean {
+  const normalized = normalizeTelegramUsername(username)
+  return (
+    normalized.length >= TELEGRAM_USERNAME_MIN_LENGTH &&
+    normalized.length <= TELEGRAM_USERNAME_MAX_LENGTH &&
+    USERNAME_REGEX.test(normalized)
+  )
 }
 
 function buildMentionMessage(users: Array<{ username: string }>) {
   return users.map((user) => getMentionLabel(user)).join(' ')
+}
+
+export function buildAllMessage(
+  users: Array<{ username: string }>,
+  query = '',
+): string {
+  const mentions = buildMentionMessage(users)
+  const normalizedQuery = query.trim()
+  return normalizedQuery ? `${mentions}\n${normalizedQuery}` : mentions
+}
+
+export function filterMentionableUsers(users: MentionableUser[]) {
+  return users.filter((user): user is { id: number; username: string } =>
+    Boolean(
+      user.id && user.username?.trim() && isTelegramUsername(user.username),
+    ),
+  )
 }
 
 function chunkUsers<T>(users: T[], chunkSize: number): T[][] {
@@ -35,6 +67,17 @@ function chunkUsers<T>(users: T[], chunkSize: number): T[][] {
   }
 
   return chunks
+}
+
+export function buildAllMentionBatches(
+  users: MentionableUser[],
+  query = '',
+  chunkSize = ALL_MENTION_BATCH_SIZE,
+): string[] {
+  const validUsers = filterMentionableUsers(users)
+  return chunkUsers(validUsers, chunkSize).map((userChunk, index) =>
+    buildAllMessage(userChunk, index === 0 ? query : ''),
+  )
 }
 
 const setupUsersCommands = (bot: Bot) => {
@@ -67,33 +110,36 @@ const setupUsersCommands = (bot: Bot) => {
 
   bot.command('all', async (ctx) => {
     const { text, replyId } = getCommandData(ctx.message)
-    const users = (await getChatUsers(ctx.chat?.id ?? '')).filter(
-      (user) =>
-        user.id && user.username?.trim() && isTelegramUsername(user.username),
-    )
+    const chatId = ctx.chat?.id
+    if (!chatId) {
+      return
+    }
 
-    if (users.length === 0) {
+    let fetchedUsers: Awaited<ReturnType<typeof getChatUsersOrThrow>>
+    try {
+      fetchedUsers = await getChatUsersOrThrow(chatId)
+    } catch {
       return ctx.reply('Error while fetching users', {
         reply_parameters: { message_id: replyId },
       })
     }
 
-    const userChunks = chunkUsers(users, ALL_MENTION_BATCH_SIZE)
-    const query = text.trim()
-    const [firstChunk, ...restChunks] = userChunks
+    const users = filterMentionableUsers(fetchedUsers)
 
-    const firstMentions = buildMentionMessage(firstChunk)
-    const firstMessage = query ? `${firstMentions}\n${query}` : firstMentions
+    if (users.length === 0) {
+      return ctx.reply('No valid usernames found', {
+        reply_parameters: { message_id: replyId },
+      })
+    }
 
-    let lastMessage = await ctx.api.sendMessage(ctx.chat.id, firstMessage, {
+    const [firstMessage, ...restMessages] = buildAllMentionBatches(users, text)
+
+    let lastMessage = await ctx.api.sendMessage(chatId, firstMessage, {
       reply_parameters: { message_id: replyId },
     })
 
-    for (const userChunk of restChunks) {
-      const mentions = buildMentionMessage(userChunk)
-      const message = query ? `${mentions}\n${query}` : mentions
-
-      lastMessage = await ctx.api.sendMessage(ctx.chat.id, message)
+    for (const message of restMessages) {
+      lastMessage = await ctx.api.sendMessage(chatId, message)
     }
 
     return lastMessage


### PR DESCRIPTION
## What changed
- switched `/all` to read structured chat users instead of building one giant mention string directly
- filtered `/all` to valid Telegram usernames only
- sent `/all` mentions in batches of 5 users per message instead of one large message
- kept the first batch as a reply to the command and sent the rest as follow-up messages in the same thread

## Why
Telegram was parsing `@username` mentions correctly, but mass mentions in a single long message were not reliably surfacing notifications. Splitting `/all` into smaller batches keeps the mention format unchanged while reducing the size of each ping message.

## Impact
- `/all` now sends several smaller mention messages instead of one long list
- invalid fallback names no longer consume mention slots
- mention format remains standard `@username`

## Validation
- `bun run biome`
- `bun run tsc`
- `bun test`