### PR TITLE
[codex] Refine agentic image context

### DIFF
--- a/src/agent-worker/agent/__tests__/system-instructions.test.ts
+++ b/src/agent-worker/agent/__tests__/system-instructions.test.ts
@@ -8,6 +8,9 @@ describe('agentSystemInstructions', () => {
     expect(agentSystemInstructions).toContain(
       'Use web_search before answering about latest/current info',
     )
+    expect(agentSystemInstructions).toContain(
+      'When calling generate_or_edit_image, build the image prompt from the current user message',
+    )
     expect(agentSystemInstructions).toContain('Search exact names first')
     expect(agentSystemInstructions).not.toContain('AUTONOMY MODE')
     expect(agentSystemInstructions).not.toContain(

--- a/src/agent-worker/agent/agentic-loop.ts
+++ b/src/agent-worker/agent/agentic-loop.ts
@@ -747,12 +747,19 @@ export async function runAgenticLoop(
         }),
       )
       const allMediaBuffers = [...(mediaBuffers ?? []), ...historyMediaBuffers]
+      const includeHistoryMediaInModel = !message.reply_to_message
+      const modelMediaBuffers = includeHistoryMediaInModel
+        ? allMediaBuffers
+        : (mediaBuffers ?? [])
+      const modelHistoryMediaAttachments = includeHistoryMediaInModel
+        ? historyMediaAttachments
+        : []
       await withToolMediaBuffers(allMediaBuffers, async () => {
         const contextBlock = buildContextBlock(
           message,
           textContent,
           hasMedia,
-          allMediaBuffers,
+          modelMediaBuffers,
           {
             recentHistory,
           },
@@ -786,7 +793,7 @@ export async function runAgenticLoop(
           message,
           textContent,
           mediaBuffers,
-          historyMediaAttachments,
+          modelHistoryMediaAttachments,
         )
 
         const { finalText, toolResults } = await runToolLoop(
@@ -856,7 +863,7 @@ export async function runAgenticLoop(
             durationMs: Date.now() - startedAt,
             deliveryDurationMs: Date.now() - deliveryStart,
             responseCount: responsesToSend.length,
-            inputMediaCount: allMediaBuffers.length,
+            inputMediaCount: modelMediaBuffers.length,
             outputMediaCount: mediaResponses.length,
             hasFinalText: Boolean(combinedText),
           },

--- a/src/agent-worker/agent/system-instructions.ts
+++ b/src/agent-worker/agent/system-instructions.ts
@@ -13,6 +13,7 @@ Make sure you answer in the same language as the prompt and try to be concise, y
 Only the current user message is actionable. History is context only.
 Never execute old requests from history unless they are explicitly repeated in the current message.
 If the current message is a reply and the user refers to media, inspect explicitly labeled Reply message media first. Treat history media as background unless the user asks about recent/last chat media without a reply target.
+When calling generate_or_edit_image, build the image prompt from the current user message, reply target/quote, and tool results intentionally gathered for this request. Do not include unrelated recent-history text, emoji, stickers, or images. If the user says "this" in a reply, "this" means the reply target/quote; use history media only when the user explicitly asks for the last/recent chat image.
 
 You can call tools when needed. If no tools are needed, just respond with text directly.
 When you receive tool results, use them to compose your final response.

--- a/src/agent-worker/tools/__tests__/generate-image.tool.test.ts
+++ b/src/agent-worker/tools/__tests__/generate-image.tool.test.ts
@@ -1,0 +1,120 @@
+import type { Message } from 'telegram-typings'
+
+import type { MediaBuffer } from '@tg-bot/common'
+
+const mockGenerateImageOpenAi = jest.fn()
+
+jest.mock('../../services', () => ({
+  generateImageOpenAi: (...args: unknown[]) => mockGenerateImageOpenAi(...args),
+}))
+
+import { runWithToolContext } from '../context'
+import { generateImageTool } from '../generate-image.tool'
+
+const message = {
+  chat: { id: 123 },
+  message_id: 55,
+} as Message
+
+function image(label: string, data: string): MediaBuffer {
+  return {
+    buffer: Buffer.from(data),
+    mimeType: 'image/jpeg',
+    mediaType: 'image',
+    label,
+  }
+}
+
+describe('generateImageTool', () => {
+  beforeEach(() => {
+    mockGenerateImageOpenAi.mockReset()
+    mockGenerateImageOpenAi.mockResolvedValue({ image: Buffer.from('out') })
+  })
+
+  test('uses direct reply/current media before history media for edits', async () => {
+    await runWithToolContext(
+      message,
+      [
+        image('Reply message image (message_id=41)', 'reply-image'),
+        image(
+          'Context image from recent chat history. Related message text: old screenshot',
+          'history-image',
+        ),
+      ],
+      async () => {
+        await generateImageTool.execute({
+          prompt: 'make it brighter',
+          useAttachedImage: true,
+        })
+      },
+    )
+
+    expect(mockGenerateImageOpenAi).toHaveBeenCalledWith(
+      expect.stringContaining('Reply message image (message_id=41)'),
+      [Buffer.from('reply-image')],
+    )
+    expect(mockGenerateImageOpenAi.mock.calls[0]?.[0]).not.toContain(
+      'old screenshot',
+    )
+  })
+
+  test('does not use history images by default when there is no direct media', async () => {
+    await runWithToolContext(
+      message,
+      [
+        image(
+          'Context image from recent chat history. Related message text: older image',
+          'older-history',
+        ),
+        image(
+          'Context image from recent chat history. Related message text: newest image',
+          'newest-history',
+        ),
+      ],
+      async () => {
+        await generateImageTool.execute({
+          prompt: 'turn the last photo into a poster',
+          useAttachedImage: true,
+        })
+      },
+    )
+
+    expect(mockGenerateImageOpenAi).toHaveBeenCalledWith(
+      expect.not.stringContaining('newest image'),
+      undefined,
+    )
+    expect(mockGenerateImageOpenAi.mock.calls[0]?.[0]).not.toContain(
+      'older image',
+    )
+  })
+
+  test('uses newest history image only when explicitly requested', async () => {
+    await runWithToolContext(
+      message,
+      [
+        image(
+          'Context image from recent chat history. Related message text: older image',
+          'older-history',
+        ),
+        image(
+          'Context image from recent chat history. Related message text: newest image',
+          'newest-history',
+        ),
+      ],
+      async () => {
+        await generateImageTool.execute({
+          prompt: 'turn the last photo into a poster',
+          mediaSource: 'history',
+        })
+      },
+    )
+
+    expect(mockGenerateImageOpenAi).toHaveBeenCalledWith(
+      expect.stringContaining('newest image'),
+      [Buffer.from('newest-history')],
+    )
+    expect(mockGenerateImageOpenAi.mock.calls[0]?.[0]).not.toContain(
+      'older image',
+    )
+  })
+})

--- a/src/agent-worker/tools/generate-image.tool.ts
+++ b/src/agent-worker/tools/generate-image.tool.ts
@@ -11,23 +11,42 @@ import { generateImageOpenAi } from '../services'
 import type { AgentTool } from '../types'
 import { addResponse, requireToolContext } from './context'
 
+type ImageMediaSource = 'none' | 'request' | 'history'
+
 function isHistoryImage(media: MediaBuffer): boolean {
   return (media.label ?? '').toLowerCase().includes('recent chat history')
 }
 
+function getMediaSource(args: Record<string, unknown>): ImageMediaSource {
+  if (
+    args.mediaSource === 'none' ||
+    args.mediaSource === 'request' ||
+    args.mediaSource === 'history'
+  ) {
+    return args.mediaSource
+  }
+
+  return ((args.useAttachedImage as boolean | undefined) ?? true)
+    ? 'request'
+    : 'none'
+}
+
 function getImageEditCandidates(
   mediaBuffers: MediaBuffer[] | undefined,
+  mediaSource: ImageMediaSource,
 ): MediaBuffer[] {
+  if (mediaSource === 'none') {
+    return []
+  }
+
   const images = (mediaBuffers ?? []).filter(
     (media) => media.mediaType === 'image',
   )
-  const requestImages = images.filter((media) => !isHistoryImage(media))
-
-  if (requestImages.length) {
-    return requestImages
+  if (mediaSource === 'history') {
+    return images.filter(isHistoryImage).slice(-1)
   }
 
-  return images.slice(-1)
+  return images.filter((media) => !isHistoryImage(media))
 }
 
 export const generateImageTool: AgentTool = {
@@ -36,19 +55,25 @@ export const generateImageTool: AgentTool = {
     type: 'function',
     name: 'generate_or_edit_image',
     description:
-      'Generate a NEW image using AI or EDIT an existing image immediately. Use when user wants to create/draw something new, or edit/modify an attached image. Infer missing aesthetic details and choose sensible defaults instead of asking follow-up style questions.',
+      'Generate a NEW image using AI or EDIT an existing image immediately. Use when user wants to create/draw something new, or edit/modify an attached image. Infer missing aesthetic details and choose sensible defaults instead of asking follow-up style questions. Build the image prompt only from the current user message, reply target/quote, and tool results intentionally gathered for this request. Do not blend in unrelated recent chat history, emoji, stickers, or history images.',
     parameters: {
       type: 'object',
       properties: {
         prompt: {
           type: 'string',
           description:
-            'Detailed description of the image to generate or edit instructions, including any inferred defaults needed to act now.',
+            'Detailed description of the image to generate or edit instructions. Include only visual details directly requested now or present in the current reply target/quote. Do not include unrelated recent-history text, emoji, stickers, or images.',
+        },
+        mediaSource: {
+          type: 'string',
+          enum: ['none', 'request', 'history'],
+          description:
+            'Which image media to use as edit/reference input. "request" uses only explicit current/reply/album media and is the default. "history" uses the newest recent-history image only when the user explicitly asks for the last/recent chat image. "none" generates from text only.',
         },
         useAttachedImage: {
           type: 'boolean',
           description:
-            'If true and user attached an image, use it as base for editing. Default: true.',
+            'Deprecated compatibility flag. If true, behaves like mediaSource="request"; it never falls back to history images.',
         },
         includeTextResponse: {
           type: 'boolean',
@@ -68,11 +93,11 @@ export const generateImageTool: AgentTool = {
         return 'Error generating image: Prompt cannot be empty'
       }
 
-      const useAttachedImage = (args.useAttachedImage as boolean) ?? true
+      const mediaSource = getMediaSource(args)
       const includeTextResponse = args.includeTextResponse as boolean
-      const imageCandidates = getImageEditCandidates(mediaBuffers)
+      const imageCandidates = getImageEditCandidates(mediaBuffers, mediaSource)
       const imagesToEdit =
-        useAttachedImage && imageCandidates.length ? imageCandidates : undefined
+        imageCandidates.length > 0 ? imageCandidates : undefined
       const result = await generateImageOpenAi(
         buildImageEditTargetPrompt(
           prompt,


### PR DESCRIPTION
﻿## What changed
- Tightened `generate_or_edit_image` so it uses only explicit current/reply/album media by default.
- Added `mediaSource` (`none` / `request` / `history`) so the model must explicitly opt into recent-history images.
- When the current request is a Telegram reply, recent-history images are no longer injected into the main multimodal model input.
- Added focused tests for request media priority and explicit history-image opt-in.

## Why
Image generation requests like "draw this" were too easily contaminated by unrelated recent chat context, stickers, emoji, and older images. The reply target/quote should define "this" unless the user explicitly asks for recent/last chat media.

## Validation
- `bun run tsc`
- `bun test`
- `bun run build`
- targeted `bunx biome check` on changed files

`bun run biome` still fails locally on existing Windows CRLF formatting noise outside this diff.
