### PR TITLE
Switch agent fast-text model to gemini-3.5-flash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@
 - `src/agent-worker/` owns all AI decisions.
 - Agent worker flow:
   1. chat enabled check
-  2. single reply gate check (Gemini 3.1 flash-lite)
-  3. main response generation (Gemini 3.1 flash-lite)
+  2. single reply gate check (Gemini 3.5 flash)
+  3. main response generation (Gemini 3.5 flash)
 
 ## Reliability Rules
 - Webhook/incoming lambda must finish under 10 seconds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,8 @@
   history inline.
 - Ingress should dispatch to workers asynchronously and return.
 - Agent worker performs:
-  1. single reply gate check with Gemini 3.1 flash-lite
-  2. agentic loop with Gemini 3.1 flash-lite
+  1. single reply gate check with Gemini 3.5 flash
+  2. agentic loop with Gemini 3.5 flash
 - Registered command dispatch:
   - `/q` and `/qq` go to `agent-worker` with reply gate bypassed.
   - other registered commands go to `telegram-reply-worker`.

--- a/src/common/utils/ai-model.utils.test.ts
+++ b/src/common/utils/ai-model.utils.test.ts
@@ -43,7 +43,7 @@ describe('ai-model.utils', () => {
 
   test('formats provider-neutral model labels', () => {
     expect(formatAiModelConfig(DEFAULT_FAST_TEXT_MODEL)).toBe(
-      'google/gemini-3.1-flash-lite',
+      'google/gemini-3.5-flash',
     )
   })
 })

--- a/src/common/utils/ai-model.utils.ts
+++ b/src/common/utils/ai-model.utils.ts
@@ -15,7 +15,7 @@ export interface AiModelConfig {
 
 export const DEFAULT_FAST_TEXT_MODEL: AiModelConfig = {
   provider: 'google',
-  model: 'gemini-3.1-flash-lite',
+  model: 'gemini-3.5-flash',
 }
 
 export const DEFAULT_HELPER_TEXT_MODEL: AiModelConfig = {


### PR DESCRIPTION
Update DEFAULT_FAST_TEXT_MODEL from gemini-3.1-flash-lite to gemini-3.5-flash, which drives the agentic loop and reply gate. Sync docs and the format assertion accordingly.