### PR TITLE
Secure Telegram webhook requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
           COMMON_GOOGLE_API_KEY: ${{secrets.COMMON_GOOGLE_API_KEY}}
           OPEN_WEATHER_MAP_TOKEN: ${{secrets.OPEN_WEATHER_MAP_TOKEN}}
           TOKEN: ${{secrets.TOKEN}}
+          TELEGRAM_WEBHOOK_SECRET: ${{secrets.TELEGRAM_WEBHOOK_SECRET}}
           YOUTUBE_TOKEN: ${{secrets.YOUTUBE_TOKEN}}
           FIXER_API_KEY: ${{secrets.FIXER_API_KEY}}
           EXCHANGE_RATE_API_KEY: ${{secrets.EXCHANGE_RATE_API_KEY}}

--- a/example.env
+++ b/example.env
@@ -1,5 +1,6 @@
 # Telegram Bot
 TOKEN=your_telegram_bot_token
+TELEGRAM_WEBHOOK_SECRET=your_random_webhook_secret
 
 # Google APIs
 COMMON_GOOGLE_API_KEY=your_google_api_key

--- a/serverless.yml
+++ b/serverless.yml
@@ -40,6 +40,7 @@ functions:
     timeout: 10
     handler: src/telegram-bot/index.default
     environment:
+      TELEGRAM_WEBHOOK_SECRET: ${env:TELEGRAM_WEBHOOK_SECRET}
       REPLY_WORKER_FUNCTION_NAME: ${self:service}-${sls:stage}-telegram-reply-worker
       AGENT_WORKER_FUNCTION_NAME: ${self:service}-${sls:stage}-telegram-agent-worker
       ACTIVITY_WORKER_FUNCTION_NAME: ${self:service}-${sls:stage}-telegram-activity-worker

--- a/src/telegram-bot/__tests__/webhook-auth.test.ts
+++ b/src/telegram-bot/__tests__/webhook-auth.test.ts
@@ -1,0 +1,31 @@
+import { hasValidTelegramWebhookSecret } from '../webhook-auth'
+
+describe('Telegram webhook authentication', () => {
+  test('accepts the configured secret regardless of header casing', () => {
+    expect(
+      hasValidTelegramWebhookSecret(
+        { 'X-Telegram-Bot-Api-Secret-Token': 'secret-value' },
+        'secret-value',
+      ),
+    ).toBe(true)
+  })
+
+  test('rejects missing or incorrect secrets', () => {
+    expect(hasValidTelegramWebhookSecret({}, 'secret-value')).toBe(false)
+    expect(
+      hasValidTelegramWebhookSecret(
+        { 'x-telegram-bot-api-secret-token': 'wrong-value' },
+        'secret-value',
+      ),
+    ).toBe(false)
+  })
+
+  test('fails closed when the expected secret is not configured', () => {
+    expect(
+      hasValidTelegramWebhookSecret(
+        { 'x-telegram-bot-api-secret-token': 'secret-value' },
+        undefined,
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/telegram-bot/index.ts
+++ b/src/telegram-bot/index.ts
@@ -13,6 +13,7 @@ import {
   getRegisteredCommandName,
 } from './command-registry'
 import { setupAllCommands } from './setup-commands'
+import { hasValidTelegramWebhookSecret } from './webhook-auth'
 
 const bot = createBot()
 
@@ -68,6 +69,16 @@ const handleUpdate = webhookCallback(bot, 'aws-lambda-async', {
 })
 
 const telegramBotHandler: APIGatewayProxyHandler = async (event, context) => {
+  if (
+    !hasValidTelegramWebhookSecret(
+      event.headers,
+      process.env.TELEGRAM_WEBHOOK_SECRET,
+    )
+  ) {
+    logger.warn({ requestId: context.awsRequestId }, 'webhook.unauthorized')
+    return { statusCode: 403, body: '' }
+  }
+
   try {
     await handleUpdate(
       { body: event.body ?? '', headers: event.headers },
@@ -76,7 +87,7 @@ const telegramBotHandler: APIGatewayProxyHandler = async (event, context) => {
 
     return {
       statusCode: 200,
-      body: JSON.stringify({ body: event.body ?? '' }),
+      body: '',
     }
   } catch (e) {
     logger.error({ error: e }, 'Bot handler error')

--- a/src/telegram-bot/webhook-auth.ts
+++ b/src/telegram-bot/webhook-auth.ts
@@ -1,0 +1,18 @@
+const TELEGRAM_SECRET_HEADER = 'x-telegram-bot-api-secret-token'
+
+type WebhookHeaders = Record<string, string | undefined> | null | undefined
+
+export function hasValidTelegramWebhookSecret(
+  headers: WebhookHeaders,
+  expectedSecret: string | undefined,
+): boolean {
+  if (!expectedSecret) {
+    return false
+  }
+
+  const receivedSecret = Object.entries(headers ?? {}).find(
+    ([name]) => name.toLowerCase() === TELEGRAM_SECRET_HEADER,
+  )?.[1]
+
+  return receivedSecret === expectedSecret
+}


### PR DESCRIPTION
## Summary
- validate the Telegram webhook secret header before processing updates
- provide the secret only to the ingress Lambda through GitHub Actions
- stop reflecting incoming Telegram updates in HTTP responses
- add focused authentication tests

## Validation
- `bun run biome`
- `bun run tsc`
- `bun test` (402 passed)
- `bun run build`