### PR TITLE
Add safe agent worker retries

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -58,6 +58,8 @@ functions:
     handler: src/agent-worker/index.default
     timeout: 300
     memorySize: 1536
+    maximumEventAge: 3600
+    maximumRetryAttempts: 2
 
   telegram-activity-worker:
     handler: src/telegram-bot/activity-worker.default

--- a/src/agent-worker/__tests__/idempotency.test.ts
+++ b/src/agent-worker/__tests__/idempotency.test.ts
@@ -1,0 +1,81 @@
+import * as common from '@tg-bot/common'
+import {
+  acquireAgentWorkerLease,
+  getAgentWorkerIdempotencyKey,
+} from '../idempotency'
+
+const mockSet = jest.fn()
+const mockEval = jest.fn()
+const redis = { set: mockSet, eval: mockEval }
+const getRedisClientSpy = jest.spyOn(common, 'getRedisClient')
+
+beforeEach(() => {
+  mockSet.mockReset()
+  mockEval.mockReset()
+  getRedisClientSpy.mockReturnValue(
+    redis as unknown as ReturnType<typeof common.getRedisClient>,
+  )
+})
+
+describe('agent worker idempotency', () => {
+  test('builds a stable per-message key', () => {
+    expect(getAgentWorkerIdempotencyKey(-100, 42)).toBe(
+      'agent-worker:message:-100:42',
+    )
+  })
+
+  test('acquires a lease and exposes atomic owner operations', async () => {
+    mockSet.mockResolvedValue('OK')
+    mockEval
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce('OK')
+      .mockResolvedValueOnce(1)
+
+    const lease = await acquireAgentWorkerLease(-100, 42, 'request-1')
+
+    expect(lease).not.toBeNull()
+    expect(mockSet).toHaveBeenCalledWith(
+      'agent-worker:message:-100:42',
+      'request-1',
+      { ex: 45, nx: true },
+    )
+    expect(await lease?.renew()).toBe(true)
+    expect(await lease?.complete()).toBe(true)
+    expect(await lease?.release()).toBe(true)
+    expect(mockEval).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      ['agent-worker:message:-100:42'],
+      ['request-1', '45'],
+    )
+  })
+
+  test('skips a message that already has a lease or completion marker', async () => {
+    mockSet.mockResolvedValue(null)
+
+    await expect(
+      acquireAgentWorkerLease(-100, 42, 'request-2'),
+    ).resolves.toBeNull()
+  })
+
+  test('does not mutate a lease owned by another invocation', async () => {
+    mockSet.mockResolvedValue('OK')
+    mockEval
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(0)
+    const lease = await acquireAgentWorkerLease(-100, 42, 'request-2')
+
+    expect(await lease?.renew()).toBe(false)
+    expect(await lease?.complete()).toBe(false)
+    expect(await lease?.release()).toBe(false)
+  })
+
+  test('fails instead of processing without idempotency storage', async () => {
+    getRedisClientSpy.mockReturnValue(null)
+
+    await expect(
+      acquireAgentWorkerLease(-100, 42, 'request-3'),
+    ).rejects.toThrow('Redis is required for agent worker idempotency')
+  })
+})

--- a/src/agent-worker/idempotency.ts
+++ b/src/agent-worker/idempotency.ts
@@ -1,0 +1,84 @@
+import { getRedisClient } from '@tg-bot/common'
+
+const KEY_PREFIX = 'agent-worker:message'
+const LEASE_TTL_SECONDS = 45
+const COMPLETED_TTL_SECONDS = 60 * 60 * 24
+
+const RENEW_LEASE_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("EXPIRE", KEYS[1], ARGV[2])
+end
+return 0
+`
+
+const COMPLETE_LEASE_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("SET", KEYS[1], "completed", "EX", ARGV[2])
+end
+return nil
+`
+
+const RELEASE_LEASE_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`
+
+export const AGENT_WORKER_HEARTBEAT_INTERVAL_MS = 15_000
+
+export interface AgentWorkerLease {
+  renew(): Promise<boolean>
+  complete(): Promise<boolean>
+  release(): Promise<boolean>
+}
+
+export function getAgentWorkerIdempotencyKey(
+  chatId: string | number,
+  messageId: number,
+): string {
+  return `${KEY_PREFIX}:${chatId}:${messageId}`
+}
+
+export async function acquireAgentWorkerLease(
+  chatId: string | number,
+  messageId: number,
+  ownerToken: string,
+): Promise<AgentWorkerLease | null> {
+  const redis = getRedisClient()
+  if (!redis) {
+    throw new Error('Redis is required for agent worker idempotency')
+  }
+
+  const key = getAgentWorkerIdempotencyKey(chatId, messageId)
+  const acquired = await redis.set(key, ownerToken, {
+    ex: LEASE_TTL_SECONDS,
+    nx: true,
+  })
+  if (acquired !== 'OK') {
+    return null
+  }
+
+  return {
+    async renew() {
+      const result = await redis.eval(
+        RENEW_LEASE_SCRIPT,
+        [key],
+        [ownerToken, String(LEASE_TTL_SECONDS)],
+      )
+      return result === 1
+    },
+    async complete() {
+      const result = await redis.eval(
+        COMPLETE_LEASE_SCRIPT,
+        [key],
+        [ownerToken, String(COMPLETED_TTL_SECONDS)],
+      )
+      return result === 'OK'
+    },
+    async release() {
+      const result = await redis.eval(RELEASE_LEASE_SCRIPT, [key], [ownerToken])
+      return result === 1
+    },
+  }
+}

--- a/src/agent-worker/index.ts
+++ b/src/agent-worker/index.ts
@@ -17,6 +17,11 @@ import {
   REPLY_GATE_MODEL,
   runAgenticLoop,
 } from './agent'
+import {
+  AGENT_WORKER_HEARTBEAT_INTERVAL_MS,
+  type AgentWorkerLease,
+  acquireAgentWorkerLease,
+} from './idempotency'
 
 const bot = createBot()
 
@@ -52,8 +57,30 @@ async function resolveBotInfo(
   }
 }
 
-const agentWorker: Handler<AgentWorkerPayload> = async (event) => {
+function startLeaseHeartbeat(
+  lease: AgentWorkerLease,
+  messageMeta: ReturnType<typeof getMessageLogMeta>,
+): ReturnType<typeof setInterval> {
+  const heartbeat = setInterval(() => {
+    void lease
+      .renew()
+      .then((renewed) => {
+        if (!renewed) {
+          logger.warn(messageMeta, 'worker.idempotency_lease_lost')
+        }
+      })
+      .catch((error) =>
+        logger.warn({ ...messageMeta, error }, 'worker.heartbeat_failed'),
+      )
+  }, AGENT_WORKER_HEARTBEAT_INTERVAL_MS)
+  heartbeat.unref()
+  return heartbeat
+}
+
+const agentWorker: Handler<AgentWorkerPayload> = async (event, context) => {
   const startedAt = Date.now()
+  let lease: AgentWorkerLease | undefined
+  let heartbeat: ReturnType<typeof setInterval> | undefined
   try {
     const { message, imagesData, imageFileIds, botInfo, bypassReplyGate } =
       event
@@ -79,6 +106,18 @@ const agentWorker: Handler<AgentWorkerPayload> = async (event) => {
       )
       return { statusCode: 200, body: 'Skipped' }
     }
+
+    lease =
+      (await acquireAgentWorkerLease(
+        message.chat.id,
+        message.message_id,
+        context.awsRequestId,
+      )) ?? undefined
+    if (!lease) {
+      logger.info(messageMeta, 'worker.duplicate_skipped')
+      return { statusCode: 200, body: 'Duplicate' }
+    }
+    heartbeat = startLeaseHeartbeat(lease, messageMeta)
 
     logger.info(
       {
@@ -124,8 +163,26 @@ const agentWorker: Handler<AgentWorkerPayload> = async (event) => {
       'worker.done',
     )
 
+    try {
+      if (!(await lease.complete())) {
+        logger.warn(messageMeta, 'worker.idempotency_completion_failed')
+      }
+    } catch (completionError) {
+      logger.warn(
+        { ...messageMeta, error: completionError },
+        'worker.idempotency_completion_failed',
+      )
+    }
+
     return { statusCode: 200, body: 'OK' }
   } catch (error) {
+    if (lease) {
+      try {
+        await lease.release()
+      } catch (releaseError) {
+        logger.warn({ error: releaseError }, 'worker.lease_release_failed')
+      }
+    }
     logger.error(
       {
         model: CHAT_MODEL_LABEL,
@@ -136,7 +193,11 @@ const agentWorker: Handler<AgentWorkerPayload> = async (event) => {
       },
       'worker.failed',
     )
-    return { statusCode: 200, body: 'Error' }
+    throw error
+  } finally {
+    if (heartbeat) {
+      clearInterval(heartbeat)
+    }
   }
 }
 


### PR DESCRIPTION
## What changed

- let unexpected agent-worker failures propagate to AWS asynchronous invocation retries
- explicitly retain failed events for one hour and allow two retry attempts
- acquire an atomic Redis lease per Telegram chat/message before processing
- renew long-running leases with a heartbeat and keep a 24-hour completion marker
- release owned leases on failure so retries can safely reacquire them

## Why

The worker caught every exception and returned a successful Lambda result, so AWS never retried transient failures. Enabling retries without idempotency would risk duplicate model runs and Telegram replies.

## Impact

Parallel or redelivered copies of the same Telegram message are skipped. Transient failures before successful completion can be retried by AWS, while successful messages remain deduplicated.

## Validation

- `bun run biome`
- `bun run tsc`
- `bun test` (417 passed)
- `bun run build`
