### PR TITLE
Make statistics writes concurrency-safe

### DIFF
--- a/src/common/aws/dynamo/__tests__/chat-events.test.ts
+++ b/src/common/aws/dynamo/__tests__/chat-events.test.ts
@@ -1,4 +1,4 @@
-import { shouldSkipStatsBroadcast } from '../chat-events'
+import { getChatEventSortKey, shouldSkipStatsBroadcast } from '../chat-events'
 
 describe('shouldSkipStatsBroadcast', () => {
   const originalEnv = process.env
@@ -29,5 +29,27 @@ describe('shouldSkipStatsBroadcast', () => {
     process.env.IS_OFFLINE = 'false'
 
     expect(shouldSkipStatsBroadcast()).toBe(false)
+  })
+})
+
+describe('getChatEventSortKey', () => {
+  test('uses the message id to avoid same-second collisions', () => {
+    const date = 1_750_000_000
+    const first = getChatEventSortKey(date, 10)
+    const second = getChatEventSortKey(date, 11)
+
+    expect(first).not.toBe(second)
+    expect(first).toBeGreaterThanOrEqual(date * 1000)
+    expect(first).toBeLessThan(date * 1000 + 1000)
+  })
+
+  test('is deterministic for duplicate delivery of the same message', () => {
+    expect(getChatEventSortKey(1_750_000_000, 42)).toBe(
+      getChatEventSortKey(1_750_000_000, 42),
+    )
+  })
+
+  test('preserves millisecond timestamps when no message id is available', () => {
+    expect(getChatEventSortKey(1_750_000_000_123)).toBe(1_750_000_000_123)
   })
 })

--- a/src/common/aws/dynamo/__tests__/chat-statistics.test.ts
+++ b/src/common/aws/dynamo/__tests__/chat-statistics.test.ts
@@ -1,4 +1,20 @@
-import { buildFormattedChatStatisticsMessages } from '../chat-statistics'
+import type { Chat, User } from 'grammy/types'
+
+import * as utils from '../../../utils'
+import {
+  buildFormattedChatStatisticsMessages,
+  setUserOptOut,
+  updateStatistics,
+} from '../chat-statistics'
+
+const querySpy = jest.spyOn(utils, 'dynamoQuery')
+const putSpy = jest.spyOn(utils, 'dynamoPutItem')
+
+beforeEach(() => {
+  querySpy.mockReset()
+  putSpy.mockReset()
+  putSpy.mockResolvedValue({} as never)
+})
 
 describe('buildFormattedChatStatisticsMessages', () => {
   test('builds plain fallback text and rich markdown table from the same stats', () => {
@@ -30,5 +46,121 @@ describe('buildFormattedChatStatisticsMessages', () => {
     expect(result.richMarkdown).toContain('Showing top 100 of 101 users.')
     expect(result.richMarkdown).not.toContain('user100')
     expect(result.text).toContain('1 (0.02%) - user100')
+  })
+})
+
+describe('concurrency-safe chat statistics writes', () => {
+  const user = { id: 7, username: 'alice' } as User
+  const chat = { id: -100, type: 'group', title: 'Test chat' } as Chat
+
+  test('creates a new statistics item only when the chat is absent', async () => {
+    querySpy.mockResolvedValue({ Items: [] } as never)
+
+    await updateStatistics(user, chat)
+
+    expect(putSpy).toHaveBeenCalledWith({
+      TableName: 'chat-statistics',
+      Item: {
+        chatId: '-100',
+        chatInfo: chat,
+        users: [{ id: 7, msgCount: 1, username: 'alice' }],
+        version: 1,
+      },
+      ConditionExpression: 'attribute_not_exists(#chatId)',
+      ExpressionAttributeNames: { '#chatId': 'chatId' },
+    })
+  })
+
+  test('re-reads and retries after a concurrent update conflict', async () => {
+    querySpy
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            chatId: '-100',
+            chatInfo: chat,
+            users: [{ id: 7, msgCount: 5, username: 'alice' }],
+            version: 1,
+          },
+        ],
+      } as never)
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            chatId: '-100',
+            chatInfo: chat,
+            users: [{ id: 7, msgCount: 6, username: 'alice' }],
+            version: 2,
+          },
+        ],
+      } as never)
+    putSpy
+      .mockRejectedValueOnce(
+        Object.assign(new Error('write conflict'), {
+          name: 'ConditionalCheckFailedException',
+        }),
+      )
+      .mockResolvedValueOnce({} as never)
+
+    await updateStatistics(user, chat)
+
+    expect(querySpy).toHaveBeenCalledTimes(2)
+    expect(putSpy).toHaveBeenCalledTimes(2)
+    expect(putSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        Item: expect.objectContaining({
+          users: [{ id: 7, msgCount: 7, username: 'alice' }],
+          version: 3,
+        }),
+        ConditionExpression: '#version = :expectedVersion',
+        ExpressionAttributeValues: { ':expectedVersion': 2 },
+      }),
+    )
+  })
+
+  test('upgrades legacy records that do not have a version', async () => {
+    querySpy.mockResolvedValue({
+      Items: [
+        {
+          chatId: '-100',
+          chatInfo: chat,
+          users: [{ id: 7, msgCount: 5, username: 'alice' }],
+        },
+      ],
+    } as never)
+
+    await updateStatistics(user, chat)
+
+    expect(putSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Item: expect.objectContaining({ version: 1 }),
+        ConditionExpression: 'attribute_not_exists(#version)',
+        ExpressionAttributeNames: { '#version': 'version' },
+      }),
+    )
+  })
+
+  test('updates opt-out state through the same version guard', async () => {
+    querySpy.mockResolvedValue({
+      Items: [
+        {
+          chatId: '-100',
+          chatInfo: chat,
+          users: [{ id: 7, msgCount: 5, username: 'alice' }],
+          version: 4,
+        },
+      ],
+    } as never)
+
+    await expect(setUserOptOut(-100, 7, true)).resolves.toBe('updated')
+    expect(putSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Item: expect.objectContaining({
+          users: [{ id: 7, msgCount: 5, username: 'alice', optedOut: true }],
+          version: 5,
+        }),
+        ConditionExpression: '#version = :expectedVersion',
+        ExpressionAttributeValues: { ':expectedVersion': 4 },
+      }),
+    )
   })
 })

--- a/src/common/aws/dynamo/chat-events.ts
+++ b/src/common/aws/dynamo/chat-events.ts
@@ -7,8 +7,21 @@ import {
   dynamoQuery,
   getOptionalEnv,
   invokeLambda,
-  random,
 } from '../../utils'
+
+const TELEGRAM_EVENT_ID_SPACE = 1_000_000
+
+export function getChatEventSortKey(date: number, messageId?: number): number {
+  const dateMs = date < 10_000_000_000 ? date * 1000 : date
+  if (!Number.isInteger(messageId) || (messageId ?? -1) < 0) {
+    return dateMs
+  }
+
+  const secondStartMs = Math.floor(dateMs / 1000) * 1000
+  return (
+    secondStartMs + ((messageId as number) % TELEGRAM_EVENT_ID_SPACE) / 1000
+  )
+}
 
 export function shouldSkipStatsBroadcast(): boolean {
   return (
@@ -44,12 +57,12 @@ export const saveEvent = async (
   chat_id?: number,
   command?: string,
   date = Date.now(),
+  messageId?: number,
 ): Promise<void> => {
   if (userInfo && chat_id) {
     const event = {
       userInfo,
-      // trying to avoid lost messages
-      date: date * 1000 + random(-500, 500),
+      date: getChatEventSortKey(date, messageId),
       chatId: String(chat_id),
       command,
     }

--- a/src/common/aws/dynamo/chat-statistics.ts
+++ b/src/common/aws/dynamo/chat-statistics.ts
@@ -8,6 +8,7 @@ interface ChatStat {
   chatId: string
   chatInfo?: Chat
   users: UserStat[]
+  version?: number
 }
 
 export interface FormattedChatStatistics {
@@ -16,6 +17,7 @@ export interface FormattedChatStatistics {
 }
 
 const RICH_STATISTICS_ROW_LIMIT = 100
+const MAX_WRITE_ATTEMPTS = 8
 
 const isUserStat = (value: unknown): value is UserStat =>
   typeof value === 'object' &&
@@ -40,8 +42,16 @@ const toChatStat = (value: unknown): ChatStat | undefined => {
     users: Array.isArray(chatStat.users)
       ? chatStat.users.filter(isUserStat)
       : [],
+    version:
+      typeof chatStat.version === 'number' ? chatStat.version : undefined,
   }
 }
+
+const isConditionalWriteConflict = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'name' in error &&
+  error.name === 'ConditionalCheckFailedException'
 
 const readChatUsers = async (chat_id: number | string): Promise<UserStat[]> =>
   (await getChatStatistic(chat_id))?.users ?? []
@@ -57,6 +67,71 @@ const getChatStatistic = async (
 
   const result = await dynamoQuery(params)
   return toChatStat(result.Items?.[0])
+}
+
+interface ChatStatMutation<T> {
+  result: T
+  next?: ChatStat
+}
+
+async function putVersionedChatStatistic(
+  current: ChatStat | undefined,
+  next: ChatStat,
+): Promise<void> {
+  const item = { ...next, version: (current?.version ?? 0) + 1 }
+
+  if (!current) {
+    await dynamoPutItem({
+      TableName: 'chat-statistics',
+      Item: item,
+      ConditionExpression: 'attribute_not_exists(#chatId)',
+      ExpressionAttributeNames: { '#chatId': 'chatId' },
+    })
+    return
+  }
+
+  const hasVersion = typeof current.version === 'number'
+  await dynamoPutItem({
+    TableName: 'chat-statistics',
+    Item: item,
+    ConditionExpression: hasVersion
+      ? '#version = :expectedVersion'
+      : 'attribute_not_exists(#version)',
+    ExpressionAttributeNames: { '#version': 'version' },
+    ...(hasVersion
+      ? { ExpressionAttributeValues: { ':expectedVersion': current.version } }
+      : {}),
+  })
+}
+
+async function mutateChatStatistic<T>(
+  chatId: string | number,
+  mutate: (current: ChatStat | undefined) => ChatStatMutation<T>,
+): Promise<T> {
+  let lastConflict: unknown
+
+  for (let attempt = 0; attempt < MAX_WRITE_ATTEMPTS; attempt += 1) {
+    const current = await getChatStatistic(chatId)
+    const mutation = mutate(current)
+    if (!mutation.next) {
+      return mutation.result
+    }
+
+    try {
+      await putVersionedChatStatistic(current, mutation.next)
+      return mutation.result
+    } catch (error) {
+      if (!isConditionalWriteConflict(error)) {
+        throw error
+      }
+      lastConflict = error
+    }
+  }
+
+  throw new Error(
+    `Could not update chat statistics after ${MAX_WRITE_ATTEMPTS} attempts`,
+    { cause: lastConflict },
+  )
 }
 
 export const getChatUsers = async (
@@ -81,27 +156,30 @@ export const setUserOptOut = async (
   user_id: number,
   optedOut: boolean,
 ): Promise<'updated' | 'no_chat' | 'no_user' | 'already_set'> => {
-  const chatStatistics = await getChatStatistic(chat_id)
+  return mutateChatStatistic(chat_id, (chatStatistics) => {
+    if (!chatStatistics) {
+      return { result: 'no_chat' }
+    }
 
-  if (!chatStatistics) {
-    return 'no_chat'
-  }
+    const user = chatStatistics.users.find((item) => item.id === user_id)
+    if (!user) {
+      return { result: 'no_user' }
+    }
 
-  const user = chatStatistics.users.find((u) => u.id === user_id)
+    if (Boolean(user.optedOut) === optedOut) {
+      return { result: 'already_set' }
+    }
 
-  if (!user) {
-    return 'no_user'
-  }
-
-  if (Boolean(user.optedOut) === optedOut) {
-    return 'already_set'
-  }
-
-  // Legacy users[] storage intentionally stays read-modify-write in this PR.
-  // Moving it to atomic map updates needs a separate data-shape change.
-  user.optedOut = optedOut
-  await dynamoPutItem({ TableName: 'chat-statistics', Item: chatStatistics })
-  return 'updated'
+    return {
+      result: 'updated',
+      next: {
+        ...chatStatistics,
+        users: chatStatistics.users.map((item) =>
+          item.id === user_id ? { ...item, optedOut } : item,
+        ),
+      },
+    }
+  })
 }
 
 export const getUsersList = async (
@@ -208,37 +286,35 @@ export const updateStatistics = async (userInfo?: User, chat?: Chat) => {
   const chat_id = chat?.id
 
   if (userInfo && chat_id) {
-    const chatStatistics = await getChatStatistic(chat_id)
-    const statistics = chatStatistics
-      ? { ...chatStatistics, chatInfo: chat }
-      : {
+    return mutateChatStatistic(chat_id, (chatStatistics) => {
+      const currentUsers = chatStatistics?.users ?? []
+      const existingUser = currentUsers.find((item) => item.id === userInfo.id)
+      const userStatistic: UserStat = existingUser
+        ? {
+            ...existingUser,
+            msgCount: existingUser.msgCount + 1,
+            username: getUserName(userInfo),
+          }
+        : {
+            id: userInfo.id,
+            msgCount: 1,
+            username: getUserName(userInfo),
+          }
+
+      return {
+        result: undefined,
+        next: {
+          ...chatStatistics,
           chatId: String(chat_id),
-          users: [] as UserStat[],
           chatInfo: chat,
-        }
-
-    let userStatistic: UserStat | undefined = statistics.users?.find(
-      (x) => x.id === userInfo.id,
-    )
-
-    if (!userStatistic) {
-      userStatistic = {
-        id: userInfo.id,
-        msgCount: 1,
-        username: getUserName(userInfo),
+          users: existingUser
+            ? currentUsers.map((item) =>
+                item.id === userInfo.id ? userStatistic : item,
+              )
+            : [...currentUsers, userStatistic],
+        },
       }
-      statistics.users = [...(statistics.users || []), userStatistic]
-    } else {
-      userStatistic.msgCount += 1
-      userStatistic.username = getUserName(userInfo)
-    }
-
-    const params = {
-      TableName: 'chat-statistics',
-      Item: statistics,
-    }
-
-    return dynamoPutItem(params)
+    })
   }
 
   return Promise.resolve()

--- a/src/telegram-bot/__tests__/activity-worker.test.ts
+++ b/src/telegram-bot/__tests__/activity-worker.test.ts
@@ -1,32 +1,34 @@
 import type { Chat, Message, User } from 'grammy/types'
 
+import * as common from '@tg-bot/common'
 import activityWorker from '../activity-worker'
 
-const updateStatisticsMock = jest.fn()
-const saveEventMock = jest.fn()
-const saveMessageMock = jest.fn()
-const loggerErrorMock = jest.fn()
-const loggerWarnMock = jest.fn()
-
-jest.mock('@tg-bot/common', () => ({
-  isAiEnabledChat: (chatId: number | string | undefined) => chatId === 123,
-  logger: {
-    info: jest.fn(),
-    error: (...args: unknown[]) => loggerErrorMock(...args),
-    warn: (...args: unknown[]) => loggerWarnMock(...args),
-  },
-  saveEvent: (...args: unknown[]) => saveEventMock(...args),
-  saveMessage: (...args: unknown[]) => saveMessageMock(...args),
-  updateStatistics: (...args: unknown[]) => updateStatisticsMock(...args),
-}))
+const updateStatisticsMock = jest.spyOn(common, 'updateStatistics')
+const saveEventMock = jest.spyOn(common, 'saveEvent')
+const saveMessageMock = jest.spyOn(common, 'saveMessage')
+const isAiEnabledChatMock = jest.spyOn(common, 'isAiEnabledChat')
+const loggerErrorMock = jest.spyOn(common.logger, 'error')
+const loggerWarnMock = jest.spyOn(common.logger, 'warn')
 
 describe('activity worker', () => {
   beforeEach(() => {
     updateStatisticsMock.mockReset().mockResolvedValue(undefined)
     saveEventMock.mockReset().mockResolvedValue(undefined)
     saveMessageMock.mockReset().mockResolvedValue(undefined)
-    loggerErrorMock.mockReset()
-    loggerWarnMock.mockReset()
+    isAiEnabledChatMock
+      .mockReset()
+      .mockImplementation((chatId) => chatId === 123)
+    loggerErrorMock.mockReset().mockImplementation(() => {})
+    loggerWarnMock.mockReset().mockImplementation(() => {})
+  })
+
+  afterAll(() => {
+    updateStatisticsMock.mockRestore()
+    saveEventMock.mockRestore()
+    saveMessageMock.mockRestore()
+    isAiEnabledChatMock.mockRestore()
+    loggerErrorMock.mockRestore()
+    loggerWarnMock.mockRestore()
   })
 
   test('tracks statistics, events and AI chat history outside ingress', async () => {
@@ -43,7 +45,7 @@ describe('activity worker', () => {
     await activityWorker({ message, command: '/x' }, {} as never, jest.fn())
 
     expect(updateStatisticsMock).toHaveBeenCalledWith(user, chat)
-    expect(saveEventMock).toHaveBeenCalledWith(user, 123, '/x', 123456)
+    expect(saveEventMock).toHaveBeenCalledWith(user, 123, '/x', 123456, 10)
     expect(saveMessageMock).toHaveBeenCalledWith(message, 123)
   })
 
@@ -74,7 +76,7 @@ describe('activity worker', () => {
     await activityWorker({ message, command: '' }, {} as never, jest.fn())
 
     expect(updateStatisticsMock).toHaveBeenCalledWith(user, chat)
-    expect(saveEventMock).toHaveBeenCalledWith(user, 999, '', 123456)
+    expect(saveEventMock).toHaveBeenCalledWith(user, 999, '', 123456, 10)
     expect(saveMessageMock).not.toHaveBeenCalled()
   })
 

--- a/src/telegram-bot/activity-worker.ts
+++ b/src/telegram-bot/activity-worker.ts
@@ -31,7 +31,13 @@ const activityWorker: Handler<ActivityWorkerPayload> = async (event) => {
 
   const tasks = [
     updateStatistics(message.from, chat),
-    saveEvent(message.from, chat.id, event.command ?? '', message.date),
+    saveEvent(
+      message.from,
+      chat.id,
+      event.command ?? '',
+      message.date,
+      message.message_id,
+    ),
   ]
 
   if (isAiEnabledChat(chat.id)) {


### PR DESCRIPTION
## What changed

- add optimistic versioning and conditional DynamoDB writes for chat statistics
- retry read/modify/write operations after concurrent writer conflicts
- use the same guarded mutation path for message counts and `/all` opt-out state
- upgrade legacy records without a `version` lazily on their next write
- derive deterministic event sort keys from Telegram `message_id` instead of random jitter
- replace a leaking activity-worker module mock with isolated spies

## Why

Two activity workers could read the same statistics item and overwrite each other's increments. Event keys also used a small random range, so same-second messages could collide and one event could replace another.

## Impact

Concurrent statistics updates no longer silently lose counts. Existing DynamoDB records remain readable and require no migration. Duplicate delivery of one Telegram message writes the same event key, while distinct same-second messages receive distinct keys.

## Validation

- `bun run biome`
- `bun run tsc`
- `bun test` (424 passed)
- `bun run build`
