### PR TITLE
Scope secrets and resources by function

### DIFF
--- a/resources.yml
+++ b/resources.yml
@@ -26,7 +26,7 @@ Resources:
   ChatStatisticsTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: chat-statistics
+      TableName: ${self:custom.chatStatisticsTableName}
       AttributeDefinitions:
         - AttributeName: chatId
           AttributeType: S
@@ -38,7 +38,7 @@ Resources:
   ChatEventsTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: chat-events
+      TableName: ${self:custom.chatEventsTableName}
       AttributeDefinitions:
         - AttributeName: chatId
           AttributeType: S
@@ -92,8 +92,8 @@ Resources:
                 Action:
                   - dynamodb:Query
                 Resource:
-                  - arn:aws:dynamodb:*:*:table/chat-statistics
-                  - arn:aws:dynamodb:*:*:table/chat-events
+                  - arn:aws:dynamodb:*:*:table/${self:custom.chatStatisticsTableName}
+                  - arn:aws:dynamodb:*:*:table/${self:custom.chatEventsTableName}
                   - arn:aws:dynamodb:*:*:table/${self:custom.websocketConnectionsTableName}/index/${self:custom.websocketConnectionsChatIdIndexName}
               - Effect: Allow
                 Action:

--- a/roleStatements.yml
+++ b/roleStatements.yml
@@ -17,7 +17,7 @@
     - dynamodb:UpdateItem
     - dynamodb:DeleteItem
   Resource:
-    - arn:aws:dynamodb:*:*:table/chat-statistics
-    - arn:aws:dynamodb:*:*:table/chat-events
+    - arn:aws:dynamodb:*:*:table/${self:custom.chatStatisticsTableName}
+    - arn:aws:dynamodb:*:*:table/${self:custom.chatEventsTableName}
     - arn:aws:dynamodb:*:*:table/${self:custom.websocketConnectionsTableName}
     - arn:aws:dynamodb:*:*:table/${self:custom.websocketConnectionsTableName}/index/${self:custom.websocketConnectionsChatIdIndexName}

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,6 +1,14 @@
 service: telegram
 useDotenv: true
 
+params:
+  default:
+    chatStatisticsTableName: ${self:service}-${sls:stage}-chat-statistics
+    chatEventsTableName: ${self:service}-${sls:stage}-chat-events
+  prod:
+    chatStatisticsTableName: chat-statistics
+    chatEventsTableName: chat-events
+
 provider:
   name: aws
   stage: prod
@@ -12,23 +20,10 @@ provider:
   environment:
     region: eu-central-1
     stage: ${sls:stage}
-    GOOGLE_CX_TOKEN: ${env:GOOGLE_CX_TOKEN}
-    COMMON_GOOGLE_API_KEY: ${env:COMMON_GOOGLE_API_KEY}
-    OPEN_WEATHER_MAP_TOKEN: ${env:OPEN_WEATHER_MAP_TOKEN}
-    TOKEN: ${env:TOKEN}
-    YOUTUBE_TOKEN: ${env:YOUTUBE_TOKEN}
-    FIXER_API_KEY: ${env:FIXER_API_KEY}
-    EXCHANGE_RATE_API_KEY: ${env:EXCHANGE_RATE_API_KEY}
-    OPENAI_API_KEY: ${env:OPENAI_API_KEY}
-    OPENAI_CHAT_IDS: ${env:OPENAI_CHAT_IDS}
-    GEMINI_API_KEY: ${env:GEMINI_API_KEY}
-    UPSTASH_REDIS_URL: ${env:UPSTASH_REDIS_URL}
-    UPSTASH_REDIS_TOKEN: ${env:UPSTASH_REDIS_TOKEN}
-    DAT1CO_API_KEY: ${env:DAT1CO_API_KEY}
-    TAVILY_API_KEY: ${env:TAVILY_API_KEY}
-    GIPHY_API_KEY: ${env:GIPHY_API_KEY}
     FRONTEND_BASE_URL: ${self:custom.frontendBaseUrl}
     CHAT_SEARCH_ALLOWED_ORIGINS: ${env:CHAT_SEARCH_ALLOWED_ORIGINS, self:custom.chatSearchAllowedOrigins}
+    CHAT_STATISTICS_TABLE_NAME: ${self:custom.chatStatisticsTableName}
+    CHAT_EVENTS_TABLE_NAME: ${self:custom.chatEventsTableName}
     WEBSOCKET_CONNECTIONS_TABLE_NAME: ${self:custom.websocketConnectionsTableName}
     WEBSOCKET_CONNECTIONS_CHAT_ID_INDEX_NAME: ${self:custom.websocketConnectionsChatIdIndexName}
   iam:
@@ -40,6 +35,7 @@ functions:
     timeout: 10
     handler: src/telegram-bot/index.default
     environment:
+      TOKEN: ${env:TOKEN}
       TELEGRAM_WEBHOOK_SECRET: ${env:TELEGRAM_WEBHOOK_SECRET}
       REPLY_WORKER_FUNCTION_NAME: ${self:service}-${sls:stage}-telegram-reply-worker
       AGENT_WORKER_FUNCTION_NAME: ${self:service}-${sls:stage}-telegram-agent-worker
@@ -53,6 +49,21 @@ functions:
     handler: src/telegram-bot/telegram-reply-worker.default
     timeout: 300
     memorySize: 1536
+    environment:
+      TOKEN: ${env:TOKEN}
+      GOOGLE_CX_TOKEN: ${env:GOOGLE_CX_TOKEN}
+      COMMON_GOOGLE_API_KEY: ${env:COMMON_GOOGLE_API_KEY}
+      OPEN_WEATHER_MAP_TOKEN: ${env:OPEN_WEATHER_MAP_TOKEN}
+      YOUTUBE_TOKEN: ${env:YOUTUBE_TOKEN}
+      FIXER_API_KEY: ${env:FIXER_API_KEY}
+      EXCHANGE_RATE_API_KEY: ${env:EXCHANGE_RATE_API_KEY}
+      OPENAI_API_KEY: ${env:OPENAI_API_KEY}
+      OPENAI_CHAT_IDS: ${env:OPENAI_CHAT_IDS}
+      GEMINI_API_KEY: ${env:GEMINI_API_KEY}
+      UPSTASH_REDIS_URL: ${env:UPSTASH_REDIS_URL}
+      UPSTASH_REDIS_TOKEN: ${env:UPSTASH_REDIS_TOKEN}
+      DAT1CO_API_KEY: ${env:DAT1CO_API_KEY}
+      TAVILY_API_KEY: ${env:TAVILY_API_KEY}
 
   telegram-agent-worker:
     handler: src/agent-worker/index.default
@@ -60,27 +71,50 @@ functions:
     memorySize: 1536
     maximumEventAge: 3600
     maximumRetryAttempts: 2
+    environment:
+      TOKEN: ${env:TOKEN}
+      GOOGLE_CX_TOKEN: ${env:GOOGLE_CX_TOKEN}
+      COMMON_GOOGLE_API_KEY: ${env:COMMON_GOOGLE_API_KEY}
+      OPEN_WEATHER_MAP_TOKEN: ${env:OPEN_WEATHER_MAP_TOKEN}
+      OPENAI_API_KEY: ${env:OPENAI_API_KEY}
+      OPENAI_CHAT_IDS: ${env:OPENAI_CHAT_IDS}
+      GEMINI_API_KEY: ${env:GEMINI_API_KEY}
+      UPSTASH_REDIS_URL: ${env:UPSTASH_REDIS_URL}
+      UPSTASH_REDIS_TOKEN: ${env:UPSTASH_REDIS_TOKEN}
+      GIPHY_API_KEY: ${env:GIPHY_API_KEY}
 
   telegram-activity-worker:
     handler: src/telegram-bot/activity-worker.default
     environment:
+      OPENAI_CHAT_IDS: ${env:OPENAI_CHAT_IDS}
+      UPSTASH_REDIS_URL: ${env:UPSTASH_REDIS_URL}
+      UPSTASH_REDIS_TOKEN: ${env:UPSTASH_REDIS_TOKEN}
       WEBSOCKET_BROADCAST_FUNCTION_NAME: ${self:service}-${sls:stage}-websocket-broadcast-stats
 
   currency-scheduler:
     handler: src/telegram-bot/currency-scheduler.default
     timeout: 300
     memorySize: 1536
+    environment:
+      TOKEN: ${env:TOKEN}
+      FIXER_API_KEY: ${env:FIXER_API_KEY}
+      EXCHANGE_RATE_API_KEY: ${env:EXCHANGE_RATE_API_KEY}
+      OPENAI_API_KEY: ${env:OPENAI_API_KEY}
+      TAVILY_API_KEY: ${env:TAVILY_API_KEY}
     events:
       - schedule:
-          name: currency-scheduler-event
+          name: ${self:service}-${sls:stage}-currency-scheduler-event
           enabled: ${env:ENABLE_SCHEDULING, true}
           rate: cron(0 9,17 ? * MON-FRI *)
 
   redis-scheduler:
     handler: src/telegram-bot/redis-scheduler.default
+    environment:
+      UPSTASH_REDIS_URL: ${env:UPSTASH_REDIS_URL}
+      UPSTASH_REDIS_TOKEN: ${env:UPSTASH_REDIS_TOKEN}
     events:
       - schedule:
-          name: redis-scheduler-event
+          name: ${self:service}-${sls:stage}-redis-scheduler-event
           enabled: ${env:ENABLE_SCHEDULING, true}
           rate: rate(1 hour)
 
@@ -169,6 +203,8 @@ custom:
     local: node24
   websocketConnectionsTableName: ${self:service}-${sls:stage}-websocket-connections
   websocketConnectionsChatIdIndexName: ${self:service}-${sls:stage}-websocket-connections-chat-id
+  chatStatisticsTableName: ${param:chatStatisticsTableName}
+  chatEventsTableName: ${param:chatEventsTableName}
   frontendBaseUrl: ${env:FRONTEND_BASE_URL, 'https://telegram-bot-ui.vercel.app'}
   chatSearchAllowedOrigins: ${self:custom.frontendBaseUrl},http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173
   serverless-offline:

--- a/src/chat-search/index.ts
+++ b/src/chat-search/index.ts
@@ -2,6 +2,7 @@ import type { APIGatewayProxyHandler, APIGatewayProxyResult } from 'aws-lambda'
 
 import {
   CHAT_SEARCH_DEFAULT_ALLOWED_ORIGINS,
+  CHAT_STATISTICS_TABLE_NAME,
   dynamoScan,
   FRONTEND_BASE_URL,
   getOptionalEnv,
@@ -80,7 +81,7 @@ const isSearchableChat = (
 const getChats = () =>
   dynamoScan<ChatStatisticsRecord>(
     {
-      TableName: 'chat-statistics',
+      TableName: CHAT_STATISTICS_TABLE_NAME,
       ProjectionExpression: 'chatInfo',
       Limit: searchScanPageLimit,
     },

--- a/src/common/aws/dynamo/chat-events.ts
+++ b/src/common/aws/dynamo/chat-events.ts
@@ -8,6 +8,7 @@ import {
   getOptionalEnv,
   invokeLambda,
 } from '../../utils'
+import { CHAT_EVENTS_TABLE_NAME } from './table-names'
 
 const TELEGRAM_EVENT_ID_SPACE = 1_000_000
 
@@ -68,7 +69,7 @@ export const saveEvent = async (
     }
 
     const params = {
-      TableName: 'chat-events',
+      TableName: CHAT_EVENTS_TABLE_NAME,
       Item: event,
     }
 
@@ -88,7 +89,7 @@ const DAY = 1000 * 60 * 60 * 24
 
 export const get24hChatStats = async (chatId: string | number) => {
   const { Items } = await dynamoQuery({
-    TableName: 'chat-events',
+    TableName: CHAT_EVENTS_TABLE_NAME,
     KeyConditionExpression: 'chatId = :chatId AND #date > :date',
     ExpressionAttributeValues: {
       ':chatId': String(Number(chatId)),

--- a/src/common/aws/dynamo/chat-statistics.ts
+++ b/src/common/aws/dynamo/chat-statistics.ts
@@ -3,6 +3,7 @@ import type { Chat, User } from 'grammy/types'
 import { logger } from '../../logger'
 import type { UserStat } from '../../types'
 import { dedent, dynamoPutItem, dynamoQuery, getUserName } from '../../utils'
+import { CHAT_STATISTICS_TABLE_NAME } from './table-names'
 
 interface ChatStat {
   chatId: string
@@ -60,7 +61,7 @@ const getChatStatistic = async (
   chat_id: number | string,
 ): Promise<ChatStat | undefined> => {
   const params = {
-    TableName: 'chat-statistics',
+    TableName: CHAT_STATISTICS_TABLE_NAME,
     ExpressionAttributeValues: { ':chatId': String(chat_id) },
     KeyConditionExpression: 'chatId = :chatId',
   }
@@ -82,7 +83,7 @@ async function putVersionedChatStatistic(
 
   if (!current) {
     await dynamoPutItem({
-      TableName: 'chat-statistics',
+      TableName: CHAT_STATISTICS_TABLE_NAME,
       Item: item,
       ConditionExpression: 'attribute_not_exists(#chatId)',
       ExpressionAttributeNames: { '#chatId': 'chatId' },
@@ -92,7 +93,7 @@ async function putVersionedChatStatistic(
 
   const hasVersion = typeof current.version === 'number'
   await dynamoPutItem({
-    TableName: 'chat-statistics',
+    TableName: CHAT_STATISTICS_TABLE_NAME,
     Item: item,
     ConditionExpression: hasVersion
       ? '#version = :expectedVersion'

--- a/src/common/aws/dynamo/index.ts
+++ b/src/common/aws/dynamo/index.ts
@@ -1,2 +1,3 @@
 export * from './chat-events'
 export * from './chat-statistics'
+export * from './table-names'

--- a/src/common/aws/dynamo/table-names.ts
+++ b/src/common/aws/dynamo/table-names.ts
@@ -1,0 +1,5 @@
+export const CHAT_STATISTICS_TABLE_NAME =
+  process.env.CHAT_STATISTICS_TABLE_NAME || 'chat-statistics'
+
+export const CHAT_EVENTS_TABLE_NAME =
+  process.env.CHAT_EVENTS_TABLE_NAME || 'chat-events'

--- a/src/telegram-bot/index.ts
+++ b/src/telegram-bot/index.ts
@@ -2,12 +2,7 @@ import { webhookCallback } from 'grammy/web'
 import type { APIGatewayProxyHandler } from 'aws-lambda'
 import type { Message } from 'grammy/types'
 
-import {
-  createBot,
-  invokeActivityLambda,
-  logger,
-  saveBotMessageMiddleware,
-} from '@tg-bot/common'
+import { createBot, invokeActivityLambda, logger } from '@tg-bot/common'
 import {
   type CommandRegistry,
   getRegisteredCommandName,
@@ -16,8 +11,6 @@ import { setupAllCommands } from './setup-commands'
 import { hasValidTelegramWebhookSecret } from './webhook-auth'
 
 const bot = createBot()
-
-bot.use(saveBotMessageMiddleware)
 
 let commandRegistry: CommandRegistry = new Set<string>()
 


### PR DESCRIPTION
## What changed

- remove API, AI, and Redis credentials from the provider-wide Lambda environment
- assign each secret only to the functions that use it
- keep the webhook ingress limited to the Telegram token and webhook secret
- remove reply-history middleware from ingress; reply and agent workers retain history ownership
- route DynamoDB access through environment-provided table names
- preserve legacy production table names while stage-scoping non-production tables
- stage-scope scheduled EventBridge rule names
- update IAM resource ARNs to follow the configured table names

## Why

Every Lambda previously received every application secret, and the two legacy DynamoDB table names collided across stages. This expanded the blast radius of any function compromise and made safe dev/staging deployment difficult.

## Impact

Production continues using `chat-statistics` and `chat-events`, so no data migration occurs. A `dev` package now targets `telegram-dev-chat-statistics` and `telegram-dev-chat-events`. Function behavior is unchanged except that ingress no longer installs a reply-history wrapper it cannot use in deferred mode.

## Validation

- `bun run biome`
- `bun run tsc`
- `bun test` (424 passed)
- `bun run build` (prod package)
- `bun run build --stage dev` (stage-isolated package)
- inspected generated CloudFormation environment key names without printing secret values
