### PR TITLE
Fix paginated chat search

### DIFF
--- a/src/chat-search/__tests__/index.test.ts
+++ b/src/chat-search/__tests__/index.test.ts
@@ -57,9 +57,9 @@ describe('chat search', () => {
       expect.objectContaining({
         TableName: 'chat-statistics',
         ProjectionExpression: 'chatInfo',
-        Limit: 100,
       }),
     )
+    expect(sendSpy.mock.calls[0][0].input).not.toHaveProperty('Limit')
     expect(response.headers).not.toHaveProperty(
       'Access-Control-Allow-Credentials',
     )
@@ -68,6 +68,39 @@ describe('chat search', () => {
       'http://localhost:5173',
     )
     expect(response.headers).toHaveProperty('Vary', 'Origin')
+  })
+
+  test('continues scanning until chats after the first page are found', async () => {
+    const sendSpy = jest
+      .spyOn(DynamoDBDocumentClient.prototype, 'send')
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          Items: [
+            { chatInfo: { id: 1, type: 'group', title: 'Another chat' } },
+          ],
+          LastEvaluatedKey: { chatId: 'first-page-end' },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          Items: [
+            { chatInfo: { id: 2, type: 'supergroup', title: 'Kabold camp' } },
+          ],
+        }),
+      )
+
+    const response = await callHandler('kabold')
+
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.body)).toEqual([
+      { id: 2, type: 'supergroup', title: 'Kabold camp' },
+    ])
+    expect(sendSpy).toHaveBeenCalledTimes(2)
+    expect(sendSpy.mock.calls[1][0].input).toEqual(
+      expect.objectContaining({
+        ExclusiveStartKey: { chatId: 'first-page-end' },
+      }),
+    )
   })
 
   test('falls back to the first allowed origin for disallowed request origins', async () => {

--- a/src/chat-search/index.ts
+++ b/src/chat-search/index.ts
@@ -13,8 +13,6 @@ import type {
   SearchableChatStatisticsRecord,
 } from './types'
 
-const searchScanPageLimit = 100
-const searchScanMaxPages = 10
 const corsAllowedMethods = 'GET,OPTIONS'
 const corsAllowedHeaders = [
   'Content-Type',
@@ -79,14 +77,10 @@ const isSearchableChat = (
   chat.chatInfo.type !== 'private'
 
 const getChats = () =>
-  dynamoScan<ChatStatisticsRecord>(
-    {
-      TableName: CHAT_STATISTICS_TABLE_NAME,
-      ProjectionExpression: 'chatInfo',
-      Limit: searchScanPageLimit,
-    },
-    { maxPages: searchScanMaxPages },
-  )
+  dynamoScan<ChatStatisticsRecord>({
+    TableName: CHAT_STATISTICS_TABLE_NAME,
+    ProjectionExpression: 'chatInfo',
+  })
 
 export const getChatByName: APIGatewayProxyHandler = async (event) => {
   const origin = getRequestOrigin(event)


### PR DESCRIPTION
## Summary

- remove the ten-page cap from chat search scans
- let DynamoDB paginate through the complete statistics table
- add a regression test for a matching chat after the first scan page

## Root cause

Production contains 5,749 chat records, but search evaluated only ten pages of 100 records. Both `Kabold camp` records were beyond that first 1,000-item window, so the API returned an empty array even though the chats existed.

## User impact

Chats anywhere in the statistics table can now be found by title or username. No frontend change is required.

## Validation

- `bun run biome`
- `bun run tsc`
- `bun test` (408 passing)
- `bun run build`
