### PR TITLE
Fix agent metrics and add dashboard

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,3 +20,5 @@ jobs:
       - run: bun run tsc
       - run: bun test
       - run: bun run build
+        env:
+          SERVERLESS_ACCESS_KEY: ${{secrets.SERVERLESS_ACCESS_KEY}}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,3 +22,18 @@ jobs:
       - run: bun run build
         env:
           SERVERLESS_ACCESS_KEY: ${{secrets.SERVERLESS_ACCESS_KEY}}
+          TOKEN: ci-placeholder
+          TELEGRAM_WEBHOOK_SECRET: ci-placeholder
+          GOOGLE_CX_TOKEN: ci-placeholder
+          COMMON_GOOGLE_API_KEY: ci-placeholder
+          OPEN_WEATHER_MAP_TOKEN: ci-placeholder
+          YOUTUBE_TOKEN: ci-placeholder
+          FIXER_API_KEY: ci-placeholder
+          EXCHANGE_RATE_API_KEY: ci-placeholder
+          OPENAI_API_KEY: ci-placeholder
+          GEMINI_API_KEY: ci-placeholder
+          OPENAI_CHAT_IDS: "0"
+          UPSTASH_REDIS_URL: https://ci.invalid
+          UPSTASH_REDIS_TOKEN: ci-placeholder
+          TAVILY_API_KEY: ci-placeholder
+          GIPHY_API_KEY: ci-placeholder

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,6 +22,8 @@ jobs:
       - run: bun run build
         env:
           SERVERLESS_ACCESS_KEY: ${{secrets.SERVERLESS_ACCESS_KEY}}
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
           TOKEN: ci-placeholder
           TELEGRAM_WEBHOOK_SECRET: ci-placeholder
           GOOGLE_CX_TOKEN: ci-placeholder

--- a/src/agent-worker/agent/__tests__/model-call.test.ts
+++ b/src/agent-worker/agent/__tests__/model-call.test.ts
@@ -190,6 +190,27 @@ describe('model-call', () => {
     )
   })
 
+  test('records explicit commands separately from agentic traffic', async () => {
+    mockGenerateText.mockResolvedValue({ text: 'ok', output: [] })
+
+    await generateModelWithRetry(
+      { prompt: 'hello' },
+      1305082,
+      'routing',
+      { provider: 'openai', model: 'gpt-5.4-nano' },
+      45_000,
+      { source: 'command', command: 'o' },
+    )
+
+    expect(mockRecordMetric).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'command',
+        command: 'o',
+        name: 'routing',
+      }),
+    )
+  })
+
   test('treats transient errors as retryable', () => {
     expect(isRetryableModelError({ status: 408 })).toBe(true)
     expect(isRetryableModelError({ status: 429 })).toBe(true)

--- a/src/agent-worker/agent/agentic-loop.ts
+++ b/src/agent-worker/agent/agentic-loop.ts
@@ -22,7 +22,6 @@ import {
   DEFAULT_AGENT_HISTORY_LIMIT,
   formatAiModelConfig,
   formatHistoryForDisplay,
-  GEMINI_FLASH_LITE_IMAGE_MODEL,
   getAiSdkProviderOptions,
   getChatMemory,
   getGlobalMemory,
@@ -36,15 +35,12 @@ import {
   startThinkingRichDraftIndicator,
   startTypingIndicator,
 } from '@tg-bot/common'
-import { IMAGE_MODEL } from '../services/openai-image'
-import { VOICE_MODEL } from '../services/openai-tts'
-import { WEB_SEARCH_MODEL } from '../services/openai-web-search'
 import {
   executeDynamicCommandFromMessage,
   getAgentTools,
   getBaseAgentTools,
   getCollectedResponses,
-  getToolCommandName,
+  getToolMetricAttribution,
   runWithToolContext,
   withToolMediaBuffers,
 } from '../tools'
@@ -67,7 +63,6 @@ import {
   CHAT_FALLBACK_REASONING_EFFORT,
   CHAT_MODEL_CONFIG,
   CHAT_MODEL_REASONING_EFFORT,
-  FAST_MODEL,
   HELPER_TEXT_MODEL_CONFIG,
   REPLY_GATE_MODEL,
   resolveAgentChatModel,
@@ -119,14 +114,6 @@ export function buildNativeTools(agentTools: AgentTool[]): ToolSet {
   )
 }
 
-/** Maps tool names to their underlying AI model for metrics */
-const TOOL_MODELS: Record<string, string> = {
-  web_search: WEB_SEARCH_MODEL,
-  generate_or_edit_image: IMAGE_MODEL,
-  generate_voice: VOICE_MODEL,
-  search_video: WEB_SEARCH_MODEL,
-  code_execution: FAST_MODEL,
-}
 const RATE_LIMITED_TOOLS = new Set(['web_search', 'search_video'])
 
 const MAX_HISTORY_IMAGE_ATTACHMENTS = 4
@@ -183,14 +170,6 @@ function getHistoryMediaPrompt(message: Message): string {
   return sourceText
     ? `Context image from recent chat history. Related message text: ${sourceText.slice(0, 200)}`
     : 'Context image from recent chat history.'
-}
-
-function getToolModel(toolName: string): string {
-  if (toolName === GENERATE_IMAGE_TOOL_NAME && getToolCommandName() === 'ge') {
-    return GEMINI_FLASH_LITE_IMAGE_MODEL.model
-  }
-
-  return TOOL_MODELS[toolName] ?? 'none'
 }
 
 export function filterToolsForRequest(
@@ -362,6 +341,7 @@ async function generateDirectSvg(
       'direct_svg',
       HELPER_TEXT_MODEL_CONFIG,
       DIRECT_SVG_MODEL_TIMEOUT_MS,
+      getToolMetricAttribution(),
     )
 
     const svg = extractSvgMarkup(result.response.text)
@@ -480,14 +460,13 @@ async function executeToolCall(
   const tool = toolByName.get(name)
   if (!tool) return { name, result: `Error: tool "${name}" not found` }
 
-  const model = getToolModel(name)
+  const attribution = getToolMetricAttribution()
   const parsedArgs = parseToolArguments(toolCall.args, chatId, name)
   if (!parsedArgs.ok) {
-    void recordMetric({
+    await recordMetric({
       type: 'tool_call',
-      source: 'agentic',
+      ...attribution,
       name,
-      model,
       chatId,
       durationMs: 0,
       success: false,
@@ -498,7 +477,10 @@ async function executeToolCall(
   }
 
   const args = parsedArgs.args
-  logger.info({ chatId, tool: name, model, payload: args }, 'tool.call')
+  logger.info(
+    { chatId, tool: name, ...attribution, payload: args },
+    'tool.call',
+  )
 
   const toolStart = Date.now()
   try {
@@ -513,20 +495,19 @@ async function executeToolCall(
     const status = getToolResultStatus(result)
     if (status === 'success') {
       logger.info(
-        { chatId, tool: name, model, durationMs, result },
+        { chatId, tool: name, ...attribution, durationMs, result },
         'tool.done',
       )
     } else {
       logger.warn(
-        { chatId, tool: name, model, durationMs, result, status },
+        { chatId, tool: name, ...attribution, durationMs, result, status },
         'tool.done_non_success',
       )
     }
-    void recordMetric({
+    await recordMetric({
       type: 'tool_call',
-      source: 'agentic',
+      ...attribution,
       name,
-      model,
       chatId,
       durationMs,
       success: status === 'success',
@@ -539,14 +520,20 @@ async function executeToolCall(
     const errorMsg = error instanceof Error ? error.message : String(error)
     const status = getMetricStatusFromError(error)
     logger.error(
-      { chatId, tool: name, model, durationMs, error: errorMsg, status },
+      {
+        chatId,
+        tool: name,
+        ...attribution,
+        durationMs,
+        error: errorMsg,
+        status,
+      },
       'tool.failed',
     )
-    void recordMetric({
+    await recordMetric({
       type: 'tool_call',
-      source: 'agentic',
+      ...attribution,
       name,
-      model,
       chatId,
       durationMs,
       success: false,
@@ -767,6 +754,7 @@ async function runToolLoop(
         iteration === 0 ? 'routing' : `iteration_${iteration}`,
         activeModelConfig,
         AGENT_ROUTING_MODEL_TIMEOUT_MS,
+        getToolMetricAttribution(),
       )
     } catch (error) {
       if (
@@ -898,6 +886,8 @@ async function runToolLoop(
         chatId,
         'finalize',
         activeModelConfig,
+        AGENT_ROUTING_MODEL_TIMEOUT_MS,
+        getToolMetricAttribution(),
       )
       activeModel = finalizeResult.model
       const finalizeResponse = finalizeResult.response
@@ -935,6 +925,9 @@ export async function runAgenticLoop(
   }
 
   const chatModel = resolveAgentChatModel(options.commandName)
+  const attribution = options.commandName
+    ? { source: 'command' as const, command: options.commandName }
+    : { source: 'agentic' as const }
 
   const messageMeta = getMessageLogMeta(message)
   const deliveryReplyMessageId = getAgentDeliveryReplyMessageId(
@@ -947,6 +940,7 @@ export async function runAgenticLoop(
       model: chatModel.label,
       reasoningEffort: chatModel.reasoningEffort,
       replyGateModel: REPLY_GATE_MODEL,
+      ...attribution,
     },
     'loop.start',
   )

--- a/src/agent-worker/agent/model-call.ts
+++ b/src/agent-worker/agent/model-call.ts
@@ -6,6 +6,7 @@ import {
   getAiSdkLanguageModel,
   getAiSdkProviderOptions,
   logger,
+  type MetricSource,
   type MetricStatus,
   recordMetric,
 } from '@tg-bot/common'
@@ -36,6 +37,11 @@ export interface GenerateModelWithRetryResult<TOOLS extends ToolSet> {
   modelConfig: AiModelConfig
   model: string
   fallbackFrom?: string
+}
+
+export interface ModelMetricAttribution {
+  source: MetricSource
+  command?: string
 }
 
 export class ModelCallTimeoutError extends Error {
@@ -163,6 +169,7 @@ export async function generateModelWithRetryWithInfo<
   metricName: string,
   modelConfig: AiModelConfig = CHAT_MODEL_CONFIG,
   timeoutMs: number = CHAT_MODEL_TIMEOUT_MS,
+  attribution: ModelMetricAttribution = { source: 'agentic' },
 ): Promise<GenerateModelWithRetryResult<TOOLS>> {
   const model = formatAiModelConfig(modelConfig)
   const startedAt = Date.now()
@@ -173,19 +180,20 @@ export async function generateModelWithRetryWithInfo<
       name: metricName,
       model,
       timeoutMs,
+      ...attribution,
     },
     'model.call_start',
   )
 
-  const track = (
+  const track = async (
     attemptStartedAt: number,
     attemptModel: string,
     status: MetricStatus = 'success',
     fallbackFrom?: string,
   ) => {
-    void recordMetric({
+    await recordMetric({
       type: 'model_call',
-      source: 'agentic',
+      ...attribution,
       name: metricName,
       model: attemptModel,
       fallbackFrom,
@@ -204,10 +212,10 @@ export async function generateModelWithRetryWithInfo<
       chatId,
       timeoutMs,
     )
-    track(startedAt, model)
+    await track(startedAt, model)
     return { response, modelConfig, model }
   } catch (primaryError) {
-    track(startedAt, model, getModelErrorStatus(primaryError))
+    await track(startedAt, model, getModelErrorStatus(primaryError))
 
     if (!shouldUseFallback(modelConfig)) {
       throw primaryError
@@ -221,6 +229,7 @@ export async function generateModelWithRetryWithInfo<
         name: metricName,
         model: fallbackModel,
         fallbackFrom: model,
+        ...attribution,
         error: primaryError,
       },
       'model.fallback_invoked',
@@ -232,6 +241,7 @@ export async function generateModelWithRetryWithInfo<
         model: fallbackModel,
         timeoutMs,
         fallbackFrom: model,
+        ...attribution,
       },
       'model.call_start',
     )
@@ -243,7 +253,7 @@ export async function generateModelWithRetryWithInfo<
         chatId,
         timeoutMs,
       )
-      track(fallbackStartedAt, fallbackModel, 'success', model)
+      await track(fallbackStartedAt, fallbackModel, 'success', model)
       return {
         response,
         modelConfig: CHAT_FALLBACK_MODEL_CONFIG,
@@ -251,7 +261,7 @@ export async function generateModelWithRetryWithInfo<
         fallbackFrom: model,
       }
     } catch (fallbackError) {
-      track(
+      await track(
         fallbackStartedAt,
         fallbackModel,
         getModelErrorStatus(fallbackError),
@@ -268,6 +278,7 @@ export async function generateModelWithRetry<TOOLS extends ToolSet = ToolSet>(
   metricName: string,
   modelConfig: AiModelConfig = CHAT_MODEL_CONFIG,
   timeoutMs: number = CHAT_MODEL_TIMEOUT_MS,
+  attribution: ModelMetricAttribution = { source: 'agentic' },
 ): Promise<GenerateTextResult<TOOLS>> {
   const result = await generateModelWithRetryWithInfo(
     params,
@@ -275,6 +286,7 @@ export async function generateModelWithRetry<TOOLS extends ToolSet = ToolSet>(
     metricName,
     modelConfig,
     timeoutMs,
+    attribution,
   )
   return result.response
 }

--- a/src/agent-worker/agent/reply-gate.ts
+++ b/src/agent-worker/agent/reply-gate.ts
@@ -116,7 +116,7 @@ function getChatId(message: Message): number | undefined {
   return typeof chatId === 'number' ? chatId : undefined
 }
 
-function recordReplyGateMetric(params: {
+async function recordReplyGateMetric(params: {
   chatId?: number
   durationMs: number
   model: string
@@ -130,7 +130,7 @@ function recordReplyGateMetric(params: {
     ? 'success'
     : getMetricStatusFromError(params.error)
 
-  void recordMetric({
+  await recordMetric({
     type: 'model_call',
     source: 'agentic',
     name: 'reply_gate',
@@ -203,7 +203,7 @@ async function callReplyGateModel(params: {
       },
       'reply_gate.done',
     )
-    recordReplyGateMetric({
+    await recordReplyGateMetric({
       chatId: params.chatId,
       durationMs,
       model: params.model,
@@ -227,7 +227,7 @@ async function callReplyGateModel(params: {
         ? 'reply_gate.fallback_failed'
         : 'reply_gate.failed',
     )
-    recordReplyGateMetric({
+    await recordReplyGateMetric({
       chatId: params.chatId,
       durationMs,
       model: params.model,

--- a/src/agent-worker/index.ts
+++ b/src/agent-worker/index.ts
@@ -139,6 +139,7 @@ const agentWorker: Handler<AgentWorkerPayload> = async (event, context) => {
         hasInlineImages: Boolean(imagesData?.length),
         imageFileIdsCount: imageFileIds?.length ?? 0,
         bypassReplyGate: Boolean(bypassReplyGate),
+        commandName,
       },
       'worker.start',
     )
@@ -170,6 +171,7 @@ const agentWorker: Handler<AgentWorkerPayload> = async (event, context) => {
         durationMs: Date.now() - startedAt,
         mediaCount: mediaData.mediaBuffers.length,
         bypassReplyGate: Boolean(bypassReplyGate),
+        commandName,
       },
       'worker.done',
     )
@@ -196,10 +198,12 @@ const agentWorker: Handler<AgentWorkerPayload> = async (event, context) => {
     }
     logger.error(
       {
+        ...(event.message ? getMessageLogMeta(event.message) : {}),
         model: chatModel.label,
         reasoningEffort: chatModel.reasoningEffort,
         replyGateModel: REPLY_GATE_MODEL,
         durationMs: Date.now() - startedAt,
+        commandName: event.commandName,
         error,
       },
       'worker.failed',

--- a/src/agent-worker/services/openai-web-search.ts
+++ b/src/agent-worker/services/openai-web-search.ts
@@ -25,7 +25,7 @@ export interface SearchWebOptions {
 
 export const WEB_SEARCH_MODEL = WEB_SEARCH_MODEL_ID
 const WEB_SEARCH_TYPE = `${WEB_SEARCH_MODEL_CONFIG.provider}_web_search`
-const WEB_SEARCH_MODEL_LABEL = `${WEB_SEARCH_MODEL_CONFIG.provider}/${WEB_SEARCH_MODEL_CONFIG.model}`
+export const WEB_SEARCH_MODEL_LABEL = `${WEB_SEARCH_MODEL_CONFIG.provider}/${WEB_SEARCH_MODEL_CONFIG.model}`
 
 function getProviderTools(): ToolSet {
   if (WEB_SEARCH_MODEL_CONFIG.provider === 'google') {

--- a/src/agent-worker/tools/__tests__/generate-image.tool.test.ts
+++ b/src/agent-worker/tools/__tests__/generate-image.tool.test.ts
@@ -11,7 +11,10 @@ jest.mock('../../services', () => ({
 }))
 
 import { runWithToolContext } from '../context'
-import { generateImageTool } from '../generate-image.tool'
+import {
+  generateImageTool,
+  getImageGenerationRoute,
+} from '../generate-image.tool'
 
 const message = {
   chat: { id: 123 },
@@ -225,4 +228,23 @@ describe('generateImageTool', () => {
       expect(mockGenerateImage).not.toHaveBeenCalled()
     },
   )
+
+  test('keeps provider routing and metric labels in one definition', () => {
+    expect(getImageGenerationRoute()).toEqual([
+      {
+        provider: 'gemini',
+        model: 'google/gemini-3.1-flash-lite-image',
+      },
+      { provider: 'openai', model: 'openai/gpt-image-2' },
+    ])
+    expect(getImageGenerationRoute('ge')).toEqual([
+      {
+        provider: 'gemini',
+        model: 'google/gemini-3.1-flash-lite-image',
+      },
+    ])
+    expect(getImageGenerationRoute('e')).toEqual([
+      { provider: 'openai', model: 'openai/gpt-image-2' },
+    ])
+  })
 })

--- a/src/agent-worker/tools/code-execution.tool.ts
+++ b/src/agent-worker/tools/code-execution.tool.ts
@@ -6,6 +6,7 @@
 import { generateText } from 'ai'
 
 import {
+  formatAiModelConfig,
   getAiSdkGoogleTools,
   getAiSdkLanguageModel,
   getErrorMessage,
@@ -13,7 +14,7 @@ import {
 import { TOOL_CALL_TIMEOUT_MS } from '../agent/config'
 import { HELPER_TEXT_MODEL_CONFIG } from '../agent/models'
 import type { AgentTool } from '../types'
-import { requireToolContext } from './context'
+import { requireToolContext, trackToolModelCall } from './context'
 
 export const codeExecutionTool: AgentTool = {
   declaration: {
@@ -45,17 +46,26 @@ export const codeExecutionTool: AgentTool = {
         return 'Code execution failed: configured helper model provider does not support Google code_execution'
       }
 
-      const result = await generateText({
-        model: getAiSdkLanguageModel(HELPER_TEXT_MODEL_CONFIG),
-        prompt: task,
-        tools: {
-          code_execution: getAiSdkGoogleTools().codeExecution({}),
+      const result = await trackToolModelCall(
+        {
+          name: 'code_execution',
+          model: formatAiModelConfig(HELPER_TEXT_MODEL_CONFIG),
+          classifyResult: (response) =>
+            response.text.trim() ? 'success' : 'error',
         },
-        toolChoice: 'auto',
-        maxRetries: 0,
-        timeout: TOOL_CALL_TIMEOUT_MS,
-        providerOptions: { google: { serviceTier: 'priority' } },
-      })
+        () =>
+          generateText({
+            model: getAiSdkLanguageModel(HELPER_TEXT_MODEL_CONFIG),
+            prompt: task,
+            tools: {
+              code_execution: getAiSdkGoogleTools().codeExecution({}),
+            },
+            toolChoice: 'auto',
+            maxRetries: 0,
+            timeout: TOOL_CALL_TIMEOUT_MS,
+            providerOptions: { google: { serviceTier: 'priority' } },
+          }),
+      )
 
       if (result.text.trim()) {
         return result.text.trim()

--- a/src/agent-worker/tools/context.ts
+++ b/src/agent-worker/tools/context.ts
@@ -1,7 +1,13 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import type { Message } from 'grammy/types'
 
-import type { ChatAdminApi, MediaBuffer } from '@tg-bot/common'
+import {
+  type ChatAdminApi,
+  type MediaBuffer,
+  type MetricSource,
+  type MetricStatus,
+  timedCall,
+} from '@tg-bot/common'
 import type { AgentResponse } from '../types'
 
 interface ToolContext {
@@ -32,6 +38,37 @@ export function getCollectedResponses(): AgentResponse[] {
 
 export function getToolCommandName(): string | undefined {
   return contextStorage.getStore()?.commandName
+}
+
+export function getToolMetricAttribution(): {
+  source: MetricSource
+  command?: string
+} {
+  const command = getToolCommandName()
+  return command ? { source: 'command', command } : { source: 'agentic' }
+}
+
+export async function trackToolModelCall<T>(
+  options: {
+    name: string
+    model: string
+    fallbackFrom?: string
+    attribution?: { source: MetricSource; command?: string }
+    classifyResult?: (result: T) => MetricStatus
+  },
+  fn: () => Promise<T>,
+): Promise<T> {
+  const { message } = requireToolContext()
+  const { attribution, ...metricOptions } = options
+  return timedCall(
+    {
+      type: 'model_call',
+      ...(attribution ?? getToolMetricAttribution()),
+      ...metricOptions,
+      chatId: message.chat.id,
+    },
+    fn,
+  )
 }
 
 export async function withToolMediaBuffers<T>(

--- a/src/agent-worker/tools/dynamic-tools.ts
+++ b/src/agent-worker/tools/dynamic-tools.ts
@@ -12,10 +12,11 @@ import {
   type SearchWebOptions,
   searchWebOpenAi as searchWeb,
   WEB_SEARCH_MODEL,
+  WEB_SEARCH_MODEL_LABEL,
   type WebSearchResponseFormat,
 } from '../services/openai-web-search'
 import type { AgentTool } from '../types'
-import { addResponse, requireToolContext } from './context'
+import { addResponse, requireToolContext, trackToolModelCall } from './context'
 
 const MAX_DYNAMIC_TOOLS = 16
 
@@ -187,11 +188,19 @@ function createDynamicTool(
           return `Error: Dynamic tool "${name}" has empty query`
         }
 
-        const text = await dependencies.searchWeb(
-          preparedQuery,
-          (args.format as 'brief' | 'detailed' | 'list') ??
-            definition.searchFormat,
-          { chatId: message.chat?.id },
+        const text = await trackToolModelCall(
+          {
+            name: 'web_search',
+            model: WEB_SEARCH_MODEL_LABEL,
+            attribution: { source: 'command', command: name },
+          },
+          () =>
+            dependencies.searchWeb(
+              preparedQuery,
+              (args.format as 'brief' | 'detailed' | 'list') ??
+                definition.searchFormat,
+              { chatId: message.chat?.id },
+            ),
         )
         addStickerResponseIfPresent()
         return text

--- a/src/agent-worker/tools/generate-image.tool.ts
+++ b/src/agent-worker/tools/generate-image.tool.ts
@@ -4,50 +4,103 @@
 
 import {
   buildImageEditTargetPrompt,
+  formatAiModelConfig,
+  GEMINI_FLASH_LITE_IMAGE_MODEL,
   getErrorMessage,
   logger,
   type MediaBuffer,
 } from '@tg-bot/common'
 import { generateImage, generateImageOpenAi } from '../services'
+import { IMAGE_MODEL } from '../services/openai-image'
 import type { AgentTool } from '../types'
-import { addResponse, requireToolContext } from './context'
+import { addResponse, requireToolContext, trackToolModelCall } from './context'
 
 type ImageMediaSource = 'none' | 'request' | 'history'
 
 const OPENAI_IMAGE_COMMANDS = new Set(['e', 'ee', 'gp', 'de'])
+const IMAGE_METRIC_NAME = 'image_generation'
+const GEMINI_IMAGE_MODEL = formatAiModelConfig(GEMINI_FLASH_LITE_IMAGE_MODEL)
+const OPENAI_IMAGE_MODEL = `openai/${IMAGE_MODEL}`
+
+type ImageGenerationResult = { image?: Buffer; text?: string }
+type ImageProvider = 'gemini' | 'openai'
+type ImageGenerationRoute = { provider: ImageProvider; model: string }
+
+const GEMINI_IMAGE_ROUTE: ImageGenerationRoute = {
+  provider: 'gemini',
+  model: GEMINI_IMAGE_MODEL,
+}
+const OPENAI_IMAGE_ROUTE: ImageGenerationRoute = {
+  provider: 'openai',
+  model: OPENAI_IMAGE_MODEL,
+}
+
+export function getImageGenerationRoute(
+  commandName?: string,
+): ImageGenerationRoute[] {
+  if (commandName && OPENAI_IMAGE_COMMANDS.has(commandName)) {
+    return [OPENAI_IMAGE_ROUTE]
+  }
+  if (commandName === 'ge') {
+    return [GEMINI_IMAGE_ROUTE]
+  }
+  return [GEMINI_IMAGE_ROUTE, OPENAI_IMAGE_ROUTE]
+}
+
+function classifyImageResult(result: ImageGenerationResult) {
+  return result.image ? ('success' as const) : ('error' as const)
+}
+
+function generateTracked(
+  route: ImageGenerationRoute,
+  prompt: string,
+  inputImages: Buffer[] | undefined,
+  fallbackFrom?: string,
+) {
+  const generate =
+    route.provider === 'gemini' ? generateImage : generateImageOpenAi
+  return trackToolModelCall(
+    {
+      name: IMAGE_METRIC_NAME,
+      model: route.model,
+      fallbackFrom,
+      classifyResult: classifyImageResult,
+    },
+    () => generate(prompt, inputImages),
+  )
+}
 
 async function generateWithFallback(
   prompt: string,
   inputImages: Buffer[] | undefined,
-  useOpenAiPrimary: boolean,
   commandName?: string,
 ) {
-  if (useOpenAiPrimary) {
-    return generateImageOpenAi(prompt, inputImages)
-  }
-
-  if (commandName === 'ge') {
-    return generateImage(prompt, inputImages)
-  }
+  const [primary, fallback] = getImageGenerationRoute(commandName)
+  if (!primary) throw new Error('Image generation route is empty')
+  if (!fallback) return generateTracked(primary, prompt, inputImages)
 
   try {
-    const result = await generateImage(prompt, inputImages)
+    const result = await generateTracked(primary, prompt, inputImages)
     if (result.image) {
       return result
     }
 
     logger.warn(
-      { commandName, reason: 'no_image' },
+      { commandName, model: primary.model, reason: 'no_image' },
       'image_gen.openai_fallback',
     )
   } catch (error) {
     logger.warn(
-      { commandName, error: getErrorMessage(error) },
+      {
+        commandName,
+        model: primary.model,
+        error: getErrorMessage(error),
+      },
       'image_gen.openai_fallback',
     )
   }
 
-  return generateImageOpenAi(prompt, inputImages)
+  return generateTracked(fallback, prompt, inputImages, primary.model)
 }
 
 function isHistoryImage(media: MediaBuffer): boolean {
@@ -144,7 +197,6 @@ export const generateImageTool: AgentTool = {
       const result = await generateWithFallback(
         imagePrompt,
         imagesToEdit?.map((media) => media.buffer),
-        Boolean(commandName && OPENAI_IMAGE_COMMANDS.has(commandName)),
         commandName,
       )
 

--- a/src/agent-worker/tools/generate-voice.tool.ts
+++ b/src/agent-worker/tools/generate-voice.tool.ts
@@ -4,8 +4,9 @@
 
 import { getErrorMessage } from '@tg-bot/common'
 import { generateVoice } from '../services'
+import { VOICE_MODEL } from '../services/openai-tts'
 import type { AgentTool } from '../types'
-import { addResponse, requireToolContext } from './context'
+import { addResponse, requireToolContext, trackToolModelCall } from './context'
 
 export const generateVoiceTool: AgentTool = {
   declaration: {
@@ -48,7 +49,10 @@ export const generateVoiceTool: AgentTool = {
           | 'onyx'
           | 'nova'
           | 'shimmer') || 'nova'
-      const buffer = await generateVoice(text, voice)
+      const buffer = await trackToolModelCall(
+        { name: 'voice_generation', model: `openai/${VOICE_MODEL}` },
+        () => generateVoice(text, voice),
+      )
 
       addResponse({ type: 'voice', buffer })
       return `Generated voice message (${voice}): "${text.slice(0, 50)}..."`

--- a/src/agent-worker/tools/index.ts
+++ b/src/agent-worker/tools/index.ts
@@ -34,8 +34,10 @@ export {
   addResponse,
   getCollectedResponses,
   getToolCommandName,
+  getToolMetricAttribution,
   requireToolContext,
   runWithToolContext,
+  trackToolModelCall,
   withToolMediaBuffers,
 } from './context'
 // Individual tools

--- a/src/agent-worker/tools/search-video.tool.ts
+++ b/src/agent-worker/tools/search-video.tool.ts
@@ -5,8 +5,9 @@
 
 import { getErrorMessage } from '@tg-bot/common'
 import { searchWeb } from '../services'
+import { WEB_SEARCH_MODEL_LABEL } from '../services/openai-web-search'
 import type { AgentTool } from '../types'
-import { addResponse, requireToolContext } from './context'
+import { addResponse, requireToolContext, trackToolModelCall } from './context'
 
 const URL_REGEX = /https?:\/\/[^\s<>)"\]}]+/i
 
@@ -52,7 +53,7 @@ export const searchVideoTool: AgentTool = {
     },
   },
   execute: async (args) => {
-    requireToolContext()
+    const { message } = requireToolContext()
 
     try {
       const query = (args.query as string).trim()
@@ -60,10 +61,15 @@ export const searchVideoTool: AgentTool = {
         return 'Error searching video: Query cannot be empty'
       }
 
-      const searchResult = await searchWeb(query, 'brief', {
-        groundedPrompt: buildVideoSearchPrompt(query),
-        fallbackQuery: query,
-      })
+      const searchResult = await trackToolModelCall(
+        { name: 'video_search', model: WEB_SEARCH_MODEL_LABEL },
+        () =>
+          searchWeb(query, 'brief', {
+            groundedPrompt: buildVideoSearchPrompt(query),
+            fallbackQuery: query,
+            chatId: message.chat.id,
+          }),
+      )
       const videoUrl = extractFirstUrl(searchResult)
 
       if (!videoUrl) {

--- a/src/agent-worker/tools/web-search.tool.ts
+++ b/src/agent-worker/tools/web-search.tool.ts
@@ -2,10 +2,11 @@ import { getErrorMessage } from '@tg-bot/common'
 import { OPENAI_WEB_SEARCH_TIMEOUT_MS } from '../agent/models'
 import {
   searchWebOpenAi,
+  WEB_SEARCH_MODEL_LABEL,
   type WebSearchResponseFormat,
 } from '../services/openai-web-search'
 import type { AgentTool } from '../types'
-import { requireToolContext } from './context'
+import { requireToolContext, trackToolModelCall } from './context'
 
 const SEARCH_FORMATS = new Set<WebSearchResponseFormat>([
   'brief',
@@ -51,9 +52,13 @@ export const webSearchTool: AgentTool = {
     }
 
     try {
-      return await searchWebOpenAi(query, getSearchFormat(args.format), {
-        chatId: message.chat?.id,
-      })
+      return await trackToolModelCall(
+        { name: 'web_search', model: WEB_SEARCH_MODEL_LABEL },
+        () =>
+          searchWebOpenAi(query, getSearchFormat(args.format), {
+            chatId: message.chat?.id,
+          }),
+      )
     } catch (error) {
       return `Error searching web: ${getErrorMessage(error)}`
     }

--- a/src/common/upstash/__tests__/metrics.test.ts
+++ b/src/common/upstash/__tests__/metrics.test.ts
@@ -5,6 +5,7 @@ const mockZrange = jest.fn()
 const mockZremrangebyscore = jest.fn()
 
 const {
+  buildMetricsReport,
   getFormattedMetrics,
   getMetrics,
   recordMetric,
@@ -28,7 +29,7 @@ beforeEach(() => {
 })
 
 describe('recordMetric', () => {
-  test('silently ignores Redis errors', async () => {
+  test('keeps Redis errors non-fatal', async () => {
     mockZadd.mockRejectedValue(new Error('redis down'))
 
     await recordMetric({
@@ -145,7 +146,7 @@ describe('getFormattedMetrics', () => {
   test('returns empty message when no metrics', async () => {
     mockZrange.mockResolvedValue([])
     const result = await getFormattedMetrics(24)
-    expect(result).toContain('No metrics')
+    expect(result).toContain('No v2 metrics')
   })
 
   test('formats timeout, error, and fallback breakdowns', async () => {
@@ -189,14 +190,14 @@ describe('getFormattedMetrics', () => {
 
     const result = await getFormattedMetrics(24)
 
-    expect(result).toContain('Metrics')
-    expect(result).toContain('33% ok')
+    expect(result).toContain('AI operations')
+    expect(result).toContain('33% healthy')
     expect(result).toContain('timeout')
     expect(result).toContain('fallback')
     expect(result).toContain('routing')
     expect(result).toContain('web_search')
     expect(result).toContain('Models')
-    expect(result).toContain('2.5-flash &lt;= 3.5-flash-lite')
+    expect(result).toContain('2.5-flash')
   })
 
   test('clamps hoursBack to safe range', async () => {
@@ -204,6 +205,50 @@ describe('getFormattedMetrics', () => {
     await getFormattedMetrics(-5)
     await getFormattedMetrics(99999)
     await getFormattedMetrics(0)
+  })
+})
+
+describe('buildMetricsReport', () => {
+  test('separates models, tools, and command attribution', () => {
+    const now = Date.now()
+    const report = buildMetricsReport(
+      [
+        {
+          type: 'model_call',
+          source: 'command',
+          command: 'e',
+          name: 'image_generation',
+          model: 'openai/gpt-image-2',
+          chatId: 1,
+          durationMs: 9000,
+          success: true,
+          status: 'success',
+          timestamp: now,
+        },
+        {
+          type: 'tool_call',
+          source: 'command',
+          command: 'e',
+          name: 'generate_or_edit_image',
+          model: 'this-must-not-appear-as-a-model',
+          chatId: 1,
+          durationMs: 9100,
+          success: true,
+          status: 'success',
+          timestamp: now,
+        },
+      ],
+      24,
+      now,
+    )
+
+    expect(report.modelCalls).toBe(1)
+    expect(report.toolCalls).toBe(1)
+    expect(report.commandCalls).toBe(2)
+    expect(report.commands[0]?.label).toBe('/e')
+    expect(report.models.map(({ label }) => label)).toEqual([
+      'openai/gpt-image-2',
+    ])
   })
 })
 

--- a/src/common/upstash/metrics.ts
+++ b/src/common/upstash/metrics.ts
@@ -1,30 +1,96 @@
 /**
- * Metrics collection — logs and stores timing data for model calls and tools.
- * Stores in Redis sorted set keyed by timestamp for time-series queries.
+ * Durable operational metrics for agent model and tool calls.
+ *
+ * Model calls and tool calls are intentionally separate. A tool may invoke a
+ * model, in which case both operations are recorded with their own duration
+ * and outcome.
  */
 
+import { randomUUID } from 'node:crypto'
+
+import { logger } from '../logger'
 import * as client from './client'
 
-const METRICS_KEY = 'agent:metrics'
-/** Keep metrics for 30 days */
+const METRICS_SCHEMA_VERSION = 2
+const METRICS_KEY = `agent:metrics:v${METRICS_SCHEMA_VERSION}`
+/** Keep metrics for 30 days. */
 const METRICS_TTL_MS = 30 * 24 * 60 * 60 * 1000
+const MAX_REPORT_GROUPS = 8
 let redisClientOverride: ReturnType<typeof client.getRedisClient> | undefined
 
 export type MetricStatus = 'success' | 'error' | 'timeout'
+export type MetricSource = 'agentic' | 'command'
+export type MetricType = 'model_call' | 'tool_call'
 
 export interface MetricEntry {
-  /** 'model_call' for AI model invocations, 'tool_call' for tool executions */
-  type: 'model_call' | 'tool_call'
-  /** 'agentic' for agent loop calls, 'command' for /q /o /ge /e etc. */
-  source: 'agentic' | 'command'
+  /** Unique member ID prevents equal concurrent calls from collapsing in Redis. */
+  id?: string
+  schemaVersion?: number
+  type: MetricType
+  source: MetricSource
+  /** Stage or tool name, for example routing or generate_or_edit_image. */
   name: string
+  /** Exact provider/model label for model_call entries only. */
   model?: string
   fallbackFrom?: string
+  /** Explicit command attribution, without the leading slash. */
+  command?: string
   chatId: number
   durationMs: number
   success: boolean
   status?: MetricStatus
   timestamp: number
+}
+
+export interface MetricOutcomeCounts {
+  success: number
+  timeout: number
+  error: number
+  fallback: number
+}
+
+export interface MetricGroupSummary extends MetricOutcomeCounts {
+  label: string
+  count: number
+  medianMs: number
+}
+
+export interface MetricTimeBucket extends MetricOutcomeCounts {
+  startMs: number
+  endMs: number
+  count: number
+}
+
+export interface MetricsReport {
+  hours: number
+  fromMs: number
+  toMs: number
+  totalOperations: number
+  successRate: number
+  medianMs: number
+  outcomes: MetricOutcomeCounts
+  modelCalls: number
+  toolCalls: number
+  modelMedianMs: number
+  toolMedianMs: number
+  agenticCalls: number
+  commandCalls: number
+  modelStages: MetricGroupSummary[]
+  tools: MetricGroupSummary[]
+  models: MetricGroupSummary[]
+  commands: MetricGroupSummary[]
+  timeline: MetricTimeBucket[]
+}
+
+type TimedCallOptions<T> = {
+  type: MetricType
+  source: MetricSource
+  name: string
+  model?: string
+  fallbackFrom?: string
+  command?: string
+  chatId: number
+  classifyResult?: (result: T) => MetricStatus
 }
 
 function normalizeMetricEntry(entry: MetricEntry): MetricEntry {
@@ -34,6 +100,24 @@ function normalizeMetricEntry(entry: MetricEntry): MetricEntry {
     status,
     success: status === 'success',
   }
+}
+
+function isMetricEntry(value: unknown): value is MetricEntry {
+  if (!value || typeof value !== 'object') return false
+  const entry = value as Partial<MetricEntry>
+  return (
+    (entry.type === 'model_call' || entry.type === 'tool_call') &&
+    (entry.source === 'agentic' || entry.source === 'command') &&
+    typeof entry.name === 'string' &&
+    entry.name.length > 0 &&
+    typeof entry.chatId === 'number' &&
+    Number.isFinite(entry.chatId) &&
+    typeof entry.durationMs === 'number' &&
+    Number.isFinite(entry.durationMs) &&
+    entry.durationMs >= 0 &&
+    typeof entry.timestamp === 'number' &&
+    Number.isFinite(entry.timestamp)
+  )
 }
 
 export function setMetricsRedisClientForTests(
@@ -69,7 +153,7 @@ export function getMetricStatusFromError(error: unknown): MetricStatus {
   return 'error'
 }
 
-/** Record a metric entry — stores in Redis for graphing (fire-and-forget) */
+/** Persist one metric. Failures remain non-fatal but are visible in logs. */
 export async function recordMetric(entry: MetricEntry): Promise<void> {
   try {
     const redis = getMetricsRedisClient()
@@ -78,30 +162,32 @@ export async function recordMetric(entry: MetricEntry): Promise<void> {
     const timestamp = Number.isFinite(entry.timestamp)
       ? entry.timestamp
       : Date.now()
-    const metricEntry = normalizeMetricEntry({ ...entry, timestamp })
-
-    await redis.zadd(METRICS_KEY, {
-      score: timestamp,
-      member: JSON.stringify(metricEntry),
+    const metricEntry = normalizeMetricEntry({
+      ...entry,
+      id: entry.id ?? randomUUID(),
+      schemaVersion: METRICS_SCHEMA_VERSION,
+      durationMs: Math.max(0, entry.durationMs),
+      timestamp,
     })
 
-    // Trim old entries (older than TTL)
-    await redis.zremrangebyscore(METRICS_KEY, 0, timestamp - METRICS_TTL_MS)
-  } catch {
-    // Silently ignore Redis errors — metrics are best-effort
+    await Promise.all([
+      redis.zadd(METRICS_KEY, {
+        score: timestamp,
+        member: JSON.stringify(metricEntry),
+      }),
+      redis.zremrangebyscore(METRICS_KEY, 0, timestamp - METRICS_TTL_MS),
+    ])
+  } catch (error) {
+    logger.warn(
+      { error, metricType: entry.type, metricName: entry.name },
+      'metrics.write_failed',
+    )
   }
 }
 
-/** Time an async operation and record metrics */
+/** Time one logical operation and persist its actual outcome. */
 export async function timedCall<T>(
-  opts: {
-    type: MetricEntry['type']
-    source: MetricEntry['source']
-    name: string
-    model?: string
-    chatId: number
-    classifyResult?: (result: T) => MetricStatus
-  },
+  opts: TimedCallOptions<T>,
   fn: () => Promise<T>,
 ): Promise<T> {
   const { classifyResult, ...metricOpts } = opts
@@ -112,7 +198,7 @@ export async function timedCall<T>(
     const end = Date.now()
     const status = classifyResult?.(result) ?? 'success'
 
-    void recordMetric({
+    await recordMetric({
       ...metricOpts,
       durationMs: end - start,
       success: status === 'success',
@@ -125,7 +211,7 @@ export async function timedCall<T>(
     const end = Date.now()
     const status = getMetricStatusFromError(error)
 
-    void recordMetric({
+    await recordMetric({
       ...metricOpts,
       durationMs: end - start,
       success: false,
@@ -137,7 +223,7 @@ export async function timedCall<T>(
   }
 }
 
-/** Retrieve metric entries from Redis within a time range */
+/** Retrieve v2 metric entries from Redis within a time range. */
 export async function getMetrics(
   fromMs: number,
   toMs: number = Date.now(),
@@ -150,22 +236,16 @@ export async function getMetrics(
     return (raw as unknown[])
       .map((value) => {
         try {
-          if (typeof value === 'string') {
-            return normalizeMetricEntry(JSON.parse(value) as MetricEntry)
-          }
-          if (typeof value === 'object' && value !== null) {
-            return normalizeMetricEntry(value as MetricEntry)
-          }
-          return null
+          const parsed =
+            typeof value === 'string' ? (JSON.parse(value) as unknown) : value
+          return isMetricEntry(parsed) ? normalizeMetricEntry(parsed) : null
         } catch {
           return null
         }
       })
-      .filter(
-        (entry): entry is MetricEntry =>
-          entry !== null && typeof entry.durationMs === 'number',
-      )
-  } catch {
+      .filter((entry): entry is MetricEntry => entry !== null)
+  } catch (error) {
+    logger.warn({ error }, 'metrics.read_failed')
     return []
   }
 }
@@ -179,159 +259,195 @@ function median(values: number[]): number {
     : (sorted[middle - 1] + sorted[middle]) / 2
 }
 
+function getOutcomeCounts(entries: MetricEntry[]): MetricOutcomeCounts {
+  return {
+    success: entries.filter((entry) => entry.status === 'success').length,
+    timeout: entries.filter((entry) => entry.status === 'timeout').length,
+    error: entries.filter((entry) => entry.status === 'error').length,
+    fallback: entries.filter((entry) => entry.fallbackFrom).length,
+  }
+}
+
+function summarizeGroups(
+  entries: MetricEntry[],
+  getLabel: (entry: MetricEntry) => string | undefined,
+): MetricGroupSummary[] {
+  const groups = new Map<string, MetricEntry[]>()
+  for (const entry of entries) {
+    const label = getLabel(entry)?.trim()
+    if (!label) continue
+    groups.set(label, [...(groups.get(label) ?? []), entry])
+  }
+
+  return [...groups.entries()]
+    .map(([label, group]) => ({
+      label,
+      count: group.length,
+      medianMs: median(group.map((entry) => entry.durationMs)),
+      ...getOutcomeCounts(group),
+    }))
+    .sort(
+      (left, right) =>
+        right.count - left.count || right.medianMs - left.medianMs,
+    )
+    .slice(0, MAX_REPORT_GROUPS)
+}
+
+function getTimeline(
+  entries: MetricEntry[],
+  fromMs: number,
+  toMs: number,
+  hours: number,
+): MetricTimeBucket[] {
+  const bucketCount = Math.min(24, Math.max(1, Math.ceil(hours)))
+  const bucketMs = Math.max(1, (toMs - fromMs) / bucketCount)
+  const buckets: MetricEntry[][] = Array.from({ length: bucketCount }, () => [])
+
+  for (const entry of entries) {
+    const index = Math.min(
+      bucketCount - 1,
+      Math.max(0, Math.floor((entry.timestamp - fromMs) / bucketMs)),
+    )
+    buckets[index]?.push(entry)
+  }
+
+  return buckets.map((bucketEntries, index) => ({
+    startMs: Math.round(fromMs + index * bucketMs),
+    endMs: Math.round(fromMs + (index + 1) * bucketMs),
+    count: bucketEntries.length,
+    ...getOutcomeCounts(bucketEntries),
+  }))
+}
+
+export function clampMetricsHours(hoursBack = 24): number {
+  return Math.max(1, Math.min(720, Math.trunc(hoursBack || 24)))
+}
+
+export function buildMetricsReport(
+  entries: MetricEntry[],
+  hoursBack = 24,
+  toMs = Date.now(),
+): MetricsReport {
+  const hours = clampMetricsHours(hoursBack)
+  const fromMs = toMs - hours * 60 * 60 * 1000
+  const inRange = entries.filter(
+    (entry) => entry.timestamp >= fromMs && entry.timestamp <= toMs,
+  )
+  const modelEntries = inRange.filter((entry) => entry.type === 'model_call')
+  const toolEntries = inRange.filter((entry) => entry.type === 'tool_call')
+  const outcomes = getOutcomeCounts(inRange)
+  const totalOperations = inRange.length
+
+  return {
+    hours,
+    fromMs,
+    toMs,
+    totalOperations,
+    successRate: totalOperations ? outcomes.success / totalOperations : 0,
+    medianMs: median(inRange.map((entry) => entry.durationMs)),
+    outcomes,
+    modelCalls: modelEntries.length,
+    toolCalls: toolEntries.length,
+    modelMedianMs: median(modelEntries.map((entry) => entry.durationMs)),
+    toolMedianMs: median(toolEntries.map((entry) => entry.durationMs)),
+    agenticCalls: inRange.filter((entry) => entry.source === 'agentic').length,
+    commandCalls: inRange.filter((entry) => entry.source === 'command').length,
+    modelStages: summarizeGroups(modelEntries, (entry) => entry.name),
+    tools: summarizeGroups(toolEntries, (entry) => entry.name),
+    models: summarizeGroups(modelEntries, (entry) => entry.model),
+    commands: summarizeGroups(
+      inRange.filter((entry) => entry.source === 'command'),
+      (entry) => (entry.command ? `/${entry.command}` : undefined),
+    ),
+    timeline: getTimeline(inRange, fromMs, toMs, hours),
+  }
+}
+
+export async function getMetricsReport(hoursBack = 24): Promise<MetricsReport> {
+  const hours = clampMetricsHours(hoursBack)
+  const toMs = Date.now()
+  const fromMs = toMs - hours * 60 * 60 * 1000
+  return buildMetricsReport(await getMetrics(fromMs, toMs), hours, toMs)
+}
+
 function fmtMs(ms: number): string {
   if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`
   return `${Math.round(ms)}ms`
 }
 
-function progressBar(ratio: number, length = 15): string {
+function progressBar(ratio: number, length = 12): string {
   const filled = Math.round(ratio * length)
   return '▰'.repeat(filled) + '▱'.repeat(length - filled)
 }
 
-function getOutcomeCounts(entries: MetricEntry[]) {
-  const success = entries.filter((entry) => entry.status === 'success').length
-  const timeout = entries.filter((entry) => entry.status === 'timeout').length
-  const error = entries.filter((entry) => entry.status === 'error').length
-  const fallback = entries.filter((entry) => entry.fallbackFrom).length
-
-  return {
-    success,
-    timeout,
-    error,
-    fallback,
-  }
-}
-
 function shortModelName(model: string): string {
-  return model.replace(/^gemini-/, '').replace(/-preview$/, '')
+  return model
+    .replace(/^(?:google|openai)\//, '')
+    .replace(/^gemini-/, '')
+    .replace(/-preview$/, '')
 }
 
 function escapeHtml(text: string): string {
   return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
-function formatOutcomeSummary(entries: MetricEntry[]): string {
-  if (entries.length === 0) return ''
-
-  const { success, timeout, error, fallback } = getOutcomeCounts(entries)
-  const parts = [`${Math.round((success / entries.length) * 100)}% ok`]
-
-  if (timeout > 0) parts.push(`${timeout} t/o`)
-  if (error > 0) parts.push(`${error} err`)
-  if (fallback > 0) parts.push(`${fallback} fb`)
-
-  return ` (${parts.join(' · ')})`
+function formatOutcomeSummary(group: MetricGroupSummary): string {
+  const parts = [`${Math.round((group.success / group.count) * 100)}% ok`]
+  if (group.timeout) parts.push(`${group.timeout} t/o`)
+  if (group.error) parts.push(`${group.error} err`)
+  if (group.fallback) parts.push(`${group.fallback} fb`)
+  return parts.join(' · ')
 }
 
-/** Format metrics into a Telegram HTML message (mobile-friendly) */
-export async function getFormattedMetrics(hoursBack = 24): Promise<string> {
-  hoursBack = Math.max(1, Math.min(720, hoursBack || 24))
-  const fromMs = Date.now() - hoursBack * 60 * 60 * 1000
-  const entries = await getMetrics(fromMs)
+function formatGroup(title: string, groups: MetricGroupSummary[]): string[] {
+  if (!groups.length) return []
+  const rows = groups.map(
+    (group) =>
+      `${group.label}  ${group.count}× ~${fmtMs(group.medianMs)} (${formatOutcomeSummary(group)})`,
+  )
+  return ['', `<b>${title}</b>`, `<pre>${escapeHtml(rows.join('\n'))}</pre>`]
+}
 
-  if (entries.length === 0) {
-    return `📊 No metrics in the last ${hoursBack}h`
+export function formatMetricsReport(report: MetricsReport): string {
+  if (!report.totalOperations) {
+    return `📊 No v2 metrics in the last ${report.hours}h`
   }
 
-  const total = entries.length
-  const { success, timeout, error, fallback } = getOutcomeCounts(entries)
-  const successRate = total > 0 ? success / total : 0
-  const agenticCount = entries.filter(
-    (entry) => entry.source === 'agentic',
-  ).length
-  const commandCount = entries.filter(
-    (entry) => entry.source === 'command',
-  ).length
-
-  const lines: string[] = []
-  const summaryCode = `${progressBar(successRate)} ${Math.round(successRate * 100)}% ok - ${total} calls`
-
-  lines.push(`<b>📊 Metrics — last ${hoursBack}h</b>`)
-  lines.push('')
-  lines.push(
-    `<code>${progressBar(successRate)} ${Math.round(successRate * 100)}% ok · ${total} calls</code>`,
-  )
-
-  lines[lines.length - 1] = `<code>${escapeHtml(summaryCode)}</code>`
-
-  const summaryParts = [
-    `🤖 Agentic: ${agenticCount}`,
-    `⚡ Commands: ${commandCount}`,
+  const successPercent = Math.round(report.successRate * 100)
+  const lines = [
+    `<b>📊 AI operations · last ${report.hours}h</b>`,
+    '',
+    `<code>${progressBar(report.successRate)} ${successPercent}% healthy · ${report.totalOperations} operations</code>`,
+    `🧠 Models: ${report.modelCalls}  🔧 Tools: ${report.toolCalls}  🤖 Agentic: ${report.agenticCalls}  ⚡ Commands: ${report.commandCalls}`,
   ]
-  if (timeout > 0) summaryParts.push(`⏱ ${timeout} timeout`)
-  if (error > 0) summaryParts.push(`❌ ${error} error`)
-  if (fallback > 0) summaryParts.push(`↪ ${fallback} fallback`)
-  lines.push(summaryParts.join('  '))
 
-  const renderGroup = (title: string, items: MetricEntry[]) => {
-    if (items.length === 0) return
-
-    const byName = new Map<string, MetricEntry[]>()
-    for (const entry of items) {
-      if (!byName.has(entry.name)) {
-        byName.set(entry.name, [])
-      }
-      byName.get(entry.name)?.push(entry)
-    }
-
-    lines.push('')
-    lines.push(`<b>${title}</b>`)
-
-    const rows: string[] = []
-    for (const [name, group] of [...byName.entries()].sort(
-      (left, right) => right[1].length - left[1].length,
-    )) {
-      const durations = group.map((entry) => entry.durationMs)
-      rows.push(
-        `${name}  ${group.length}× ~${fmtMs(median(durations))}${formatOutcomeSummary(group)}`,
-      )
-    }
-
-    lines.push(`<pre>${rows.join('\n')}</pre>`)
-    lines[lines.length - 1] = `<pre>${escapeHtml(rows.join('\n'))}</pre>`
+  const incidents: string[] = []
+  if (report.outcomes.timeout) {
+    incidents.push(`⏱ ${report.outcomes.timeout} timeout`)
   }
-
-  renderGroup(
-    '🤖 Agentic',
-    entries.filter((entry) => entry.source === 'agentic'),
-  )
-  renderGroup(
-    '⚡ Commands',
-    entries.filter((entry) => entry.source === 'command'),
-  )
-
-  const modelEntries = entries.filter((entry) => entry.model)
-  if (modelEntries.length > 0) {
-    const byModel = new Map<string, MetricEntry[]>()
-    for (const entry of modelEntries) {
-      const modelName = entry.model ?? ''
-      const label = entry.fallbackFrom
-        ? `${shortModelName(modelName)} <= ${shortModelName(entry.fallbackFrom)}`
-        : shortModelName(modelName)
-
-      if (!byModel.has(label)) {
-        byModel.set(label, [])
-      }
-      byModel.get(label)?.push(entry)
-    }
-
-    lines.push('')
-    lines.push('<b>🧠 Models</b>')
-
-    const rows: string[] = []
-    for (const [label, group] of [...byModel.entries()].sort(
-      (left, right) => right[1].length - left[1].length,
-    )) {
-      const durations = group.map((entry) => entry.durationMs)
-      rows.push(
-        `${label}  ${group.length}× ~${fmtMs(median(durations))}${formatOutcomeSummary(group)}`,
-      )
-    }
-
-    lines.push(`<pre>${rows.join('\n')}</pre>`)
-    lines[lines.length - 1] = `<pre>${escapeHtml(rows.join('\n'))}</pre>`
+  if (report.outcomes.error) incidents.push(`❌ ${report.outcomes.error} error`)
+  if (report.outcomes.fallback) {
+    incidents.push(`↪ ${report.outcomes.fallback} fallback`)
   }
+  if (incidents.length) lines.push(incidents.join('  '))
+
+  lines.push(...formatGroup('🧠 Model stages', report.modelStages))
+  lines.push(...formatGroup('🔧 Tools', report.tools))
+  lines.push(
+    ...formatGroup(
+      '⚙ Models',
+      report.models.map((group) => ({
+        ...group,
+        label: shortModelName(group.label),
+      })),
+    ),
+  )
+  lines.push(...formatGroup('⚡ Commands', report.commands))
 
   return lines.join('\n')
+}
+
+/** Telegram HTML fallback used when the PNG dashboard cannot be rendered. */
+export async function getFormattedMetrics(hoursBack = 24): Promise<string> {
+  return formatMetricsReport(await getMetricsReport(hoursBack))
 }

--- a/src/sharp-renderer/__tests__/metrics-dashboard.component.test.ts
+++ b/src/sharp-renderer/__tests__/metrics-dashboard.component.test.ts
@@ -1,0 +1,68 @@
+import sharp from 'sharp'
+
+import { buildMetricsReport, type MetricEntry } from '@tg-bot/common'
+import { getMetricsDashboardSvg } from '../metrics-dashboard.component'
+
+const NOW = Date.UTC(2026, 6, 30, 12)
+
+function metric(
+  overrides: Partial<MetricEntry> & Pick<MetricEntry, 'type' | 'name'>,
+): MetricEntry {
+  return {
+    source: 'agentic',
+    chatId: 1,
+    durationMs: 1000,
+    success: true,
+    status: 'success',
+    timestamp: NOW - 60 * 60 * 1000,
+    ...overrides,
+  }
+}
+
+describe('getMetricsDashboardSvg', () => {
+  test('renders a readable 1200x980 PNG dashboard', async () => {
+    const report = buildMetricsReport(
+      [
+        metric({
+          type: 'model_call',
+          name: 'routing',
+          model: 'google/gemini-3.6-flash',
+          durationMs: 6300,
+        }),
+        metric({
+          type: 'model_call',
+          name: 'image_generation',
+          model: 'google/gemini-3.1-flash-lite-image',
+          durationMs: 9700,
+        }),
+        metric({
+          type: 'tool_call',
+          name: 'generate_or_edit_image',
+          durationMs: 9800,
+        }),
+        metric({
+          type: 'model_call',
+          source: 'command',
+          command: 'o',
+          name: 'finalize',
+          model: 'openai/gpt-5.6',
+          durationMs: 20_000,
+          success: false,
+          status: 'timeout',
+        }),
+      ],
+      24,
+      NOW,
+    )
+    const svg = getMetricsDashboardSvg(report)
+    const image = await sharp(Buffer.from(svg)).png().toBuffer()
+    const metadata = await sharp(image).metadata()
+
+    expect(svg).toContain('AI OPERATIONS')
+    expect(svg).toContain('generate_or_edit_image')
+    expect(svg).toContain('google/gemini-3.1')
+    expect(metadata.format).toBe('png')
+    expect(metadata.width).toBe(1200)
+    expect(metadata.height).toBe(980)
+  })
+})

--- a/src/sharp-renderer/index.ts
+++ b/src/sharp-renderer/index.ts
@@ -1,9 +1,14 @@
 import sharp from 'sharp'
 import type { APIGatewayProxyHandler } from 'aws-lambda'
 
-import { type CurrencyRateSection, get24hChatStats } from '@tg-bot/common'
+import {
+  type CurrencyRateSection,
+  get24hChatStats,
+  type MetricsReport,
+} from '@tg-bot/common'
 import { getCurrencyRatesSvg } from './currency-rates.component'
 import { getDailyUsersBarsSvg } from './daily-users-bars.component'
+import { getMetricsDashboardSvg } from './metrics-dashboard.component'
 
 type CurrencyRatesEvent = {
   currencyBackgroundImage?: string
@@ -15,6 +20,10 @@ type SvgRenderEvent = {
   width?: unknown
   height?: unknown
   backgroundColor?: unknown
+}
+
+type MetricsDashboardEvent = {
+  metricsReport?: unknown
 }
 
 type RenderPngOptions = {
@@ -135,7 +144,27 @@ function pngResponse(image: Buffer) {
   }
 }
 
+function isMetricsReport(value: unknown): value is MetricsReport {
+  if (!value || typeof value !== 'object') return false
+  const report = value as Partial<MetricsReport>
+  return (
+    typeof report.hours === 'number' &&
+    typeof report.toMs === 'number' &&
+    typeof report.totalOperations === 'number' &&
+    Array.isArray(report.timeline) &&
+    Array.isArray(report.modelStages) &&
+    Array.isArray(report.tools) &&
+    Array.isArray(report.models)
+  )
+}
+
 const sharpRendererHandler: APIGatewayProxyHandler = async (event) => {
+  const metricsReport = (event as MetricsDashboardEvent).metricsReport
+  if (isMetricsReport(metricsReport)) {
+    const image = await renderSvgPng(getMetricsDashboardSvg(metricsReport))
+    return pngResponse(image)
+  }
+
   const svgPayload = (event as SvgRenderEvent).svg
   if (typeof svgPayload === 'string') {
     try {

--- a/src/sharp-renderer/metrics-dashboard.component.tsx
+++ b/src/sharp-renderer/metrics-dashboard.component.tsx
@@ -1,0 +1,510 @@
+import ReactDOMServer from 'react-dom/server'
+
+import type { MetricGroupSummary, MetricsReport } from '@tg-bot/common'
+
+const WIDTH = 1200
+const HEIGHT = 980
+const PADDING = 56
+const CONTENT_WIDTH = WIDTH - PADDING * 2
+const CARD_GAP = 18
+const CARD_WIDTH = (CONTENT_WIDTH - CARD_GAP * 3) / 4
+
+const COLORS = {
+  background: '#07111f',
+  surface: '#0e1b2d',
+  surfaceStrong: '#13243a',
+  border: '#203754',
+  text: '#f4f7fb',
+  muted: '#91a6c3',
+  grid: '#1b304a',
+  blue: '#60a5fa',
+  cyan: '#22d3ee',
+  green: '#34d399',
+  amber: '#fbbf24',
+  red: '#fb7185',
+  violet: '#a78bfa',
+} as const
+
+function formatDuration(ms: number) {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`
+  return `${Math.round(ms)}ms`
+}
+
+function formatGeneratedAt(timestamp: number) {
+  return new Date(timestamp)
+    .toISOString()
+    .replace('T', ' ')
+    .replace(/:\d{2}\.\d{3}Z$/, ' UTC')
+}
+
+function successPercent(group: MetricGroupSummary) {
+  return group.count ? Math.round((group.success / group.count) * 100) : 0
+}
+
+function truncateLabel(label: string, maxLength = 31) {
+  return label.length > maxLength ? `${label.slice(0, maxLength - 1)}…` : label
+}
+
+function StatCard({
+  index,
+  label,
+  value,
+  detail,
+  accent,
+}: {
+  index: number
+  label: string
+  value: string
+  detail: string
+  accent: string
+}) {
+  const x = PADDING + index * (CARD_WIDTH + CARD_GAP)
+  const y = 116
+
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={CARD_WIDTH}
+        height={126}
+        rx={20}
+        fill={COLORS.surface}
+        stroke={COLORS.border}
+      />
+      <rect x={x} y={y} width={5} height={126} rx={2.5} fill={accent} />
+      <text x={x + 24} y={y + 33} fill={COLORS.muted} fontSize={16}>
+        {label.toUpperCase()}
+      </text>
+      <text
+        x={x + 24}
+        y={y + 79}
+        fill={COLORS.text}
+        fontSize={38}
+        fontWeight={700}
+      >
+        {value}
+      </text>
+      <text x={x + 24} y={y + 106} fill={COLORS.muted} fontSize={15}>
+        {detail}
+      </text>
+    </g>
+  )
+}
+
+function ActivityChart({ report }: { report: MetricsReport }) {
+  const x = PADDING
+  const y = 282
+  const width = CONTENT_WIDTH
+  const height = 258
+  const plotX = x + 28
+  const plotY = y + 62
+  const plotWidth = width - 56
+  const plotHeight = 144
+  const maxCount = Math.max(1, ...report.timeline.map((bucket) => bucket.count))
+  const slotWidth = plotWidth / Math.max(1, report.timeline.length)
+  const barWidth = Math.max(7, Math.min(30, slotWidth * 0.62))
+
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        rx={22}
+        fill={COLORS.surface}
+        stroke={COLORS.border}
+      />
+      <text
+        x={x + 28}
+        y={y + 34}
+        fill={COLORS.text}
+        fontSize={20}
+        fontWeight={700}
+      >
+        OPERATION VOLUME
+      </text>
+      <text
+        x={x + width - 28}
+        y={y + 34}
+        fill={COLORS.muted}
+        fontSize={15}
+        textAnchor="end"
+      >
+        success / timeout / error
+      </text>
+
+      {[0, 0.5, 1].map((ratio) => {
+        const gridY = plotY + plotHeight * ratio
+        return (
+          <line
+            key={ratio}
+            x1={plotX}
+            y1={gridY}
+            x2={plotX + plotWidth}
+            y2={gridY}
+            stroke={COLORS.grid}
+          />
+        )
+      })}
+
+      {report.timeline.map((bucket, index) => {
+        const centerX = plotX + slotWidth * index + slotWidth / 2
+        const totalHeight = (bucket.count / maxCount) * plotHeight
+        const successHeight = bucket.count
+          ? (bucket.success / bucket.count) * totalHeight
+          : 0
+        const timeoutHeight = bucket.count
+          ? (bucket.timeout / bucket.count) * totalHeight
+          : 0
+        const errorHeight = bucket.count
+          ? (bucket.error / bucket.count) * totalHeight
+          : 0
+        const bottom = plotY + plotHeight
+
+        return (
+          <g key={bucket.startMs}>
+            {bucket.count === 0 ? (
+              <rect
+                x={centerX - barWidth / 2}
+                y={bottom - 2}
+                width={barWidth}
+                height={2}
+                rx={1}
+                fill={COLORS.grid}
+              />
+            ) : null}
+            <rect
+              x={centerX - barWidth / 2}
+              y={bottom - successHeight}
+              width={barWidth}
+              height={successHeight}
+              rx={successHeight === totalHeight ? 4 : 0}
+              fill={COLORS.green}
+            />
+            <rect
+              x={centerX - barWidth / 2}
+              y={bottom - successHeight - timeoutHeight}
+              width={barWidth}
+              height={timeoutHeight}
+              fill={COLORS.amber}
+            />
+            <rect
+              x={centerX - barWidth / 2}
+              y={bottom - successHeight - timeoutHeight - errorHeight}
+              width={barWidth}
+              height={errorHeight}
+              rx={4}
+              fill={COLORS.red}
+            />
+          </g>
+        )
+      })}
+
+      <text x={plotX} y={y + 230} fill={COLORS.muted} fontSize={14}>
+        -{report.hours}h
+      </text>
+      <text
+        x={plotX + plotWidth / 2}
+        y={y + 230}
+        fill={COLORS.muted}
+        fontSize={14}
+        textAnchor="middle"
+      >
+        -{Math.round(report.hours / 2)}h
+      </text>
+      <text
+        x={plotX + plotWidth}
+        y={y + 230}
+        fill={COLORS.muted}
+        fontSize={14}
+        textAnchor="end"
+      >
+        now
+      </text>
+    </g>
+  )
+}
+
+function BusiestOperations({ report }: { report: MetricsReport }) {
+  const x = PADDING
+  const y = 580
+  const width = 530
+  const rows = [
+    ...report.modelStages.map((group) => ({ ...group, kind: 'M' })),
+    ...report.tools.map((group) => ({ ...group, kind: 'T' })),
+  ]
+    .sort(
+      (left, right) =>
+        right.count - left.count || right.medianMs - left.medianMs,
+    )
+    .slice(0, 6)
+  const maxCount = Math.max(1, ...rows.map((row) => row.count))
+
+  return (
+    <g>
+      <text x={x} y={y} fill={COLORS.text} fontSize={20} fontWeight={700}>
+        BUSIEST OPERATIONS
+      </text>
+      <text
+        x={x + width}
+        y={y}
+        fill={COLORS.muted}
+        fontSize={14}
+        textAnchor="end"
+      >
+        count · p50 latency
+      </text>
+      {rows.map((row, index) => {
+        const rowY = y + 34 + index * 55
+        const barWidth = (row.count / maxCount) * (width - 190)
+        return (
+          <g key={`${row.kind}-${row.label}`}>
+            <rect
+              x={x}
+              y={rowY}
+              width={34}
+              height={26}
+              rx={8}
+              fill={row.kind === 'M' ? COLORS.violet : COLORS.blue}
+              opacity={0.2}
+            />
+            <text
+              x={x + 17}
+              y={rowY + 18}
+              fill={row.kind === 'M' ? COLORS.violet : COLORS.blue}
+              fontSize={13}
+              fontWeight={700}
+              textAnchor="middle"
+            >
+              {row.kind}
+            </text>
+            <text x={x + 46} y={rowY + 18} fill={COLORS.text} fontSize={16}>
+              {truncateLabel(row.label, 27)}
+            </text>
+            <text
+              x={x + width}
+              y={rowY + 18}
+              fill={COLORS.muted}
+              fontSize={15}
+              textAnchor="end"
+            >
+              {row.count}× · {formatDuration(row.medianMs)}
+            </text>
+            <rect
+              x={x + 46}
+              y={rowY + 34}
+              width={width - 46}
+              height={5}
+              rx={2.5}
+              fill={COLORS.grid}
+            />
+            <rect
+              x={x + 46}
+              y={rowY + 34}
+              width={Math.max(3, barWidth)}
+              height={5}
+              rx={2.5}
+              fill={row.kind === 'M' ? COLORS.violet : COLORS.blue}
+            />
+          </g>
+        )
+      })}
+    </g>
+  )
+}
+
+function ModelRows({ report }: { report: MetricsReport }) {
+  const x = 626
+  const y = 580
+  const width = WIDTH - PADDING - x
+  const rows = report.models.slice(0, 6)
+
+  return (
+    <g>
+      <text x={x} y={y} fill={COLORS.text} fontSize={20} fontWeight={700}>
+        MODELS
+      </text>
+      <text
+        x={x + width}
+        y={y}
+        fill={COLORS.muted}
+        fontSize={14}
+        textAnchor="end"
+      >
+        health · calls · p50
+      </text>
+      {rows.map((row, index) => {
+        const rowY = y + 34 + index * 55
+        const percent = successPercent(row)
+        const healthColor =
+          percent >= 95
+            ? COLORS.green
+            : percent >= 80
+              ? COLORS.amber
+              : COLORS.red
+
+        return (
+          <g key={row.label}>
+            <circle cx={x + 7} cy={rowY + 12} r={6} fill={healthColor} />
+            <text x={x + 24} y={rowY + 18} fill={COLORS.text} fontSize={16}>
+              {truncateLabel(row.label, 29)}
+            </text>
+            <text
+              x={x + width}
+              y={rowY + 18}
+              fill={COLORS.muted}
+              fontSize={15}
+              textAnchor="end"
+            >
+              {percent}% · {row.count}× · {formatDuration(row.medianMs)}
+            </text>
+            <rect
+              x={x + 24}
+              y={rowY + 34}
+              width={width - 24}
+              height={5}
+              rx={2.5}
+              fill={COLORS.grid}
+            />
+            <rect
+              x={x + 24}
+              y={rowY + 34}
+              width={((width - 24) * percent) / 100}
+              height={5}
+              rx={2.5}
+              fill={healthColor}
+            />
+          </g>
+        )
+      })}
+    </g>
+  )
+}
+
+export function MetricsDashboard({ report }: { report: MetricsReport }) {
+  const success = Math.round(report.successRate * 100)
+  const incidents = report.outcomes.timeout + report.outcomes.error
+
+  return (
+    <svg
+      width={WIDTH}
+      height={HEIGHT}
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      xmlns="http://www.w3.org/2000/svg"
+      fontFamily="Roboto, Arial, sans-serif"
+    >
+      <title>AI operations metrics dashboard</title>
+      <desc>
+        {success}% successful across {report.totalOperations} model and tool
+        operations in the last {report.hours} hours.
+      </desc>
+      <defs>
+        <linearGradient id="metrics-bg" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stopColor={COLORS.background} />
+          <stop offset="1" stopColor="#0a1830" />
+        </linearGradient>
+        <radialGradient id="metrics-glow" cx="0.78" cy="0.05" r="0.62">
+          <stop offset="0" stopColor={COLORS.blue} stopOpacity={0.14} />
+          <stop offset="1" stopColor={COLORS.blue} stopOpacity={0} />
+        </radialGradient>
+      </defs>
+      <rect width={WIDTH} height={HEIGHT} fill="url(#metrics-bg)" />
+      <rect width={WIDTH} height={HEIGHT} fill="url(#metrics-glow)" />
+
+      <text
+        x={PADDING}
+        y={54}
+        fill={COLORS.cyan}
+        fontSize={15}
+        fontWeight={700}
+      >
+        AI OPERATIONS
+      </text>
+      <text
+        x={PADDING}
+        y={91}
+        fill={COLORS.text}
+        fontSize={31}
+        fontWeight={700}
+      >
+        Last {report.hours} hours
+      </text>
+      <text
+        x={WIDTH - PADDING}
+        y={81}
+        fill={COLORS.muted}
+        fontSize={15}
+        textAnchor="end"
+      >
+        {formatGeneratedAt(report.toMs)}
+      </text>
+
+      <StatCard
+        index={0}
+        label="Operation health"
+        value={`${success}%`}
+        detail={`${report.outcomes.success}/${report.totalOperations} successful`}
+        accent={
+          success >= 95
+            ? COLORS.green
+            : success >= 80
+              ? COLORS.amber
+              : COLORS.red
+        }
+      />
+      <StatCard
+        index={1}
+        label="Model calls"
+        value={String(report.modelCalls)}
+        detail={`${formatDuration(report.modelMedianMs)} p50 latency`}
+        accent={COLORS.violet}
+      />
+      <StatCard
+        index={2}
+        label="Tool calls"
+        value={String(report.toolCalls)}
+        detail={`${formatDuration(report.toolMedianMs)} p50 latency`}
+        accent={COLORS.blue}
+      />
+      <StatCard
+        index={3}
+        label="Incidents"
+        value={String(incidents)}
+        detail={`${report.outcomes.fallback} fallbacks · ${report.outcomes.timeout} timeouts`}
+        accent={incidents ? COLORS.red : COLORS.green}
+      />
+
+      <ActivityChart report={report} />
+      <BusiestOperations report={report} />
+      <ModelRows report={report} />
+
+      <line
+        x1={PADDING}
+        y1={932}
+        x2={WIDTH - PADDING}
+        y2={932}
+        stroke={COLORS.border}
+      />
+      <text x={PADDING} y={960} fill={COLORS.muted} fontSize={15}>
+        Agentic {report.agenticCalls} ops · Commands {report.commandCalls} ops
+      </text>
+      <text
+        x={WIDTH - PADDING}
+        y={960}
+        fill={COLORS.muted}
+        fontSize={15}
+        textAnchor="end"
+      >
+        M = model stage · T = tool
+      </text>
+    </svg>
+  )
+}
+
+export function getMetricsDashboardSvg(report: MetricsReport): string {
+  return ReactDOMServer.renderToStaticMarkup(
+    <MetricsDashboard report={report} />,
+  )
+}

--- a/src/telegram-bot/users/index.ts
+++ b/src/telegram-bot/users/index.ts
@@ -2,10 +2,11 @@ import { InputFile } from 'grammy/web'
 import type { Bot } from 'grammy/web'
 
 import {
+  formatMetricsReport,
   getChatName,
   getCommandData,
   getFormattedChatStatisticsMessages,
-  getFormattedMetrics,
+  getMetricsReport,
   getStoredChatUsers,
   isAiEnabledChat,
   logger,
@@ -14,6 +15,7 @@ import {
   setUserOptOut,
 } from '@tg-bot/common'
 import { getDailyStatistics } from './daily-statistics'
+import { getMetricsDashboardImage } from './metrics-dashboard'
 
 const USERNAME_REGEX = /^[A-Za-z0-9_]+$/
 const TELEGRAM_USERNAME_MIN_LENGTH = 5
@@ -222,7 +224,27 @@ const setupUsersCommands = (bot: Bot) => {
     const rawHours = text.trim()
     const parsedHours = rawHours ? Number(rawHours) : Number.NaN
     const hours = Number.isFinite(parsedHours) ? Math.trunc(parsedHours) : 24
-    return ctx.reply(await getFormattedMetrics(hours), {
+    const report = await getMetricsReport(hours)
+    const fallbackText = formatMetricsReport(report)
+    const image = report.totalOperations
+      ? await getMetricsDashboardImage(report)
+      : null
+
+    if (image) {
+      try {
+        return await ctx.replyWithPhoto(
+          new InputFile(image, 'ai-operations.png'),
+          {
+            reply_parameters: { message_id: replyId },
+            caption: `AI operations · last ${report.hours}h · ${Math.round(report.successRate * 100)}% healthy · ${report.totalOperations} ops`,
+          },
+        )
+      } catch (error) {
+        logger.warn({ chatId: ctx.chat.id, error }, 'metrics.image_send_failed')
+      }
+    }
+
+    return ctx.reply(fallbackText, {
       reply_parameters: { message_id: replyId },
       parse_mode: 'HTML',
     })

--- a/src/telegram-bot/users/metrics-dashboard.ts
+++ b/src/telegram-bot/users/metrics-dashboard.ts
@@ -1,0 +1,42 @@
+import {
+  getRequiredEnv,
+  invokeLambda,
+  logger,
+  type MetricsReport,
+  safeJSONParse,
+} from '@tg-bot/common'
+
+export async function getMetricsDashboardImage(
+  report: MetricsReport,
+): Promise<Buffer | null> {
+  try {
+    const response = await invokeLambda({
+      name: getRequiredEnv('SHARP_RENDERER_FUNCTION_NAME'),
+      customEndpoint: true,
+      payload: { metricsReport: report },
+    })
+
+    if (response.FunctionError) {
+      logger.warn(
+        { error: response.FunctionError },
+        'metrics.image_function_error',
+      )
+      return null
+    }
+
+    const payload = safeJSONParse(new TextDecoder().decode(response.Payload))
+    if (payload?.statusCode !== 200 || typeof payload.body !== 'string') {
+      logger.warn(
+        { statusCode: payload?.statusCode, error: payload?.body },
+        'metrics.image_render_failed',
+      )
+      return null
+    }
+
+    const image = Buffer.from(payload.body, 'base64')
+    return image.byteLength ? image : null
+  } catch (error) {
+    logger.warn({ error }, 'metrics.image_failed')
+    return null
+  }
+}


### PR DESCRIPTION
## What changed

- record model calls and tool calls as separate operations with exact provider/model attribution
- attribute explicit commands separately from ordinary agentic traffic
- record Gemini image generation and OpenAI fallback attempts accurately
- prevent Redis sorted-set collisions with unique metric IDs and move corrected data to the v2 key
- add structured logging for metric failures and worker command context
- replace the cramped `/x` output with an SVG dashboard rendered to PNG, while retaining an HTML text fallback

## Why

Image tool metrics were assigned from a static tool-to-model map. Natural image generation actually tries Gemini first and only falls back to OpenAI, so the report could incorrectly show every image call as `gpt-image-2`. Command traffic was also recorded as agentic, and tool entries polluted the model breakdown.

## Impact

The dashboard now reflects the operations that actually ran, including separate fallback attempts, command attribution, health, latency, and hourly volume. Existing incorrect history is intentionally excluded by the v2 Redis key.

## Validation

- `bun run biome`
- `bun run tsc`
- `bun test` — 433 passed
- `bun run build`
- rendered and visually inspected the 1200×980 PNG dashboard
