### PR TITLE
Remove static AWS credentials from PR checks

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   checks:
     runs-on: ubuntu-latest
@@ -14,6 +18,12 @@ jobs:
         with:
           bun-version-file: .bun-version
 
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_PACKAGE_ROLE_ARN }}
+          aws-region: eu-central-1
+          role-session-name: telegram-bot-pr-${{ github.run_id }}
+
       - run: bun install --frozen-lockfile
       - run: bun run audit
       - run: bun run biome
@@ -22,8 +32,6 @@ jobs:
       - run: bun run build
         env:
           SERVERLESS_ACCESS_KEY: ${{secrets.SERVERLESS_ACCESS_KEY}}
-          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
           TOKEN: ci-placeholder
           TELEGRAM_WEBHOOK_SECRET: ci-placeholder
           GOOGLE_CX_TOKEN: ci-placeholder


### PR DESCRIPTION
## What changed

- grant the pull-request workflow OIDC token permission
- assume a dedicated `github-telegram-bot-app-package` role
- remove repository AWS access-key secrets from the build step

## Security

The PR packaging role has no AWS resource policies. It exists only so Serverless can resolve the account ID through STS while packaging; PR code receives no production deployment permissions.

## Validation

A local package run with invalid placeholder credentials confirmed that Serverless requires STS identity. This PR validates the minimal OIDC identity through GitHub Actions before repository secrets are removed.